### PR TITLE
Fixes to allow for configuring the host ip to be used when communication w/ nodes

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
@@ -146,6 +146,8 @@ public class Config {
     initializeVideoRecorder();
     getConfigMap().put(HTML_RENDER_OPTIONS, new HtmlConfig());
 
+    getConfigMap().put(HOST_IP, null);
+
   }
 
   public boolean getAutoUpdateDrivers() {

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
@@ -51,6 +51,7 @@ public class Config {
   public static final String CONFIG_PULLER_HTTP_TIMEOUT = "config_puller_http_timeout";
   public static final String HTML_RENDER_OPTIONS = "html_render_options";
 
+  public static final String HOST_IP = "host";
 
   private static Logger logger = Logger.getLogger(Config.class);
 
@@ -375,6 +376,9 @@ public class Config {
     getConfigMap().put(DEFAULT_ROLE, defaultRole);
   }
 
+  public void setHostIp(String hostIp) {
+    getConfigMap().put(HOST_IP, hostIp);
+  }
   public void setAutoStartHub(String autoStartHub) {
     getConfigMap().put(AUTO_START_HUB, autoStartHub);
   }
@@ -480,4 +484,7 @@ public class Config {
     return (HtmlConfig) getConfigMap().get(HTML_RENDER_OPTIONS);
   }
 
+  public String getHostIp() {
+        return (String) getConfigMap().get(HOST_IP);
+  }
 }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/DefaultConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/DefaultConfig.java
@@ -284,7 +284,7 @@ public class DefaultConfig {
         config.getHub()
                 .setServlets("com.groupon.seleniumgridextras.grid.servlets.ProxyStatusJsonServlet");
 
-        String hostIp = RuntimeConfig.getOS().getHostIp();
+        String hostIp = RuntimeConfig.getHostIp();
         if (hostIp != null) {
             config.getHub().setHost(hostIp);
         }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridNode.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridNode.java
@@ -168,6 +168,7 @@ public class GridNode {
         private int unregisterIfStillDownAfter = 10000;
         private int hubPort;
         private String hubHost;
+        private String host;
         //    private int browserTimeout = 120;
 //    private int timeout = 120;
         private int nodeStatusCheckTimeout = 10000;
@@ -205,6 +206,14 @@ public class GridNode {
 
         public void setHubHost(String hubHost) {
             this.hubHost = hubHost;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public void setHost(String host) {
+            this.host = host;
         }
 
     }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/RuntimeConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/RuntimeConfig.java
@@ -184,6 +184,24 @@ public class RuntimeConfig {
     return currentOS;
   }
 
+  public static String getHostIp() {
+    String ip = null;
+    if (config != null) {
+        if (config.getHostIp() != null) {
+            ip = config.getHostIp();
+        } else if (config.getDefaultRole().equals("hub") && config.getHubs().size() > 0) {
+            ip = config.getHubs().get(0).getConfiguration().getHost();
+        } else if (config.getDefaultRole().equals("node") && config.getNodes().size() > 0) {
+            ip = config.getNodes().get(0).getConfiguration().getHost();
+        }
+    }
+    if (ip == null) {
+        ip = currentOS.getHostIp();
+    }
+    return ip;
+  }
+
+
   public static SessionTracker getTestSessionTracker() {
     if (sessionTracker == null) {
       sessionTracker = new SessionTracker();

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
@@ -150,8 +150,8 @@ public class GridStarter {
 
     String host = "";
 
-    if (RuntimeConfig.getOS().getHostIp() != null) {
-      host = " -host " + RuntimeConfig.getOS().getHostIp();
+    if (RuntimeConfig.getHostIp() != null) {
+      host = " -host " + RuntimeConfig.getHostIp();
     }
 
     if (RuntimeConfig.getOS().getHostName() != null) {

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/homepage/HtmlNodeRenderer.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/homepage/HtmlNodeRenderer.java
@@ -293,7 +293,7 @@ public class HtmlNodeRenderer {
 
   protected String getMachineInfo() {
     return RuntimeConfig.getOS().getHostName() +
-           " (" + RuntimeConfig.getOS().getHostIp() + ")";
+           " (" + RuntimeConfig.getHostIp() + ")";
   }
   
   protected String getVersionInfo() {

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/Screenshot.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/Screenshot.java
@@ -136,7 +136,7 @@ public class Screenshot extends ExecuteOSTask {
       getJsonResponse().addKeyValues(JsonCodec.Images.IMAGE, encodedImage);
 
       getJsonResponse().addKeyValues(JsonCodec.OS.HOSTNAME, RuntimeConfig.getOS().getHostName());
-      getJsonResponse().addKeyValues(JsonCodec.OS.IP, RuntimeConfig.getOS().getHostIp());
+      getJsonResponse().addKeyValues(JsonCodec.OS.IP, RuntimeConfig.getHostIp());
       Date newTimestamp = new java.sql.Timestamp(Calendar.getInstance().getTime().getTime());
       getJsonResponse().addKeyValues(JsonCodec.TIMESTAMP, newTimestamp.toString());
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/SystemInfo.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/SystemInfo.java
@@ -94,7 +94,7 @@ public class SystemInfo extends ExecuteOSTask {
     }
 
     getJsonResponse().addKeyValues(JsonCodec.OS.HOSTNAME, RuntimeConfig.getOS().getHostName());
-    getJsonResponse().addKeyValues(JsonCodec.OS.IP, RuntimeConfig.getOS().getHostIp());
+    getJsonResponse().addKeyValues(JsonCodec.OS.IP, RuntimeConfig.getHostIp());
 
     return getJsonResponse().getJson();
   }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/VideoRecorder.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/VideoRecorder.java
@@ -100,7 +100,7 @@ public class VideoRecorder extends ExecuteOSTask {
                         "Unrecognized action: %s, for session: %s, on host: %s",
                         action,
                         session,
-                        RuntimeConfig.getOS().getHostIp());
+                        RuntimeConfig.getHostIp());
 
                 logger.warn(error);
                 getJsonResponse().addKeyValues(JsonCodec.ERROR, error);
@@ -134,7 +134,7 @@ public class VideoRecorder extends ExecuteOSTask {
             String message = String.format(
                     "Starting video recording for session: %s, on host: %s, done: %s, cancelled: %s",
                     session,
-                    RuntimeConfig.getOS().getHostIp(),
+                    RuntimeConfig.getHostIp(),
                     f.isDone(),
                     f.isCancelled());
             logger.info(message);
@@ -171,7 +171,7 @@ public class VideoRecorder extends ExecuteOSTask {
             String error = String.format("Error stopping video for session: %s, host: %s, IP: %s, \n%s",
                     session,
                     RuntimeConfig.getOS().getHostName(),
-                    RuntimeConfig.getOS().getHostIp(),
+                    RuntimeConfig.getHostIp(),
                     Throwables.getStackTraceAsString(e));
 
             logger.error(error);
@@ -226,7 +226,7 @@ public class VideoRecorder extends ExecuteOSTask {
         try {
             URIBuilder uriBuilder = new URIBuilder();
             uriBuilder.setScheme("http");
-            uriBuilder.setHost(RuntimeConfig.getOS().getHostIp());
+            uriBuilder.setHost(RuntimeConfig.getHostIp());
             uriBuilder.setPort(3000);
             uriBuilder.setPath(VideoHttpExecutor.GET_VIDEO_FILE_ENDPOINT + "/" + fileName);
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/VideoDownloaderCallable.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/VideoDownloaderCallable.java
@@ -60,7 +60,7 @@ public class VideoDownloaderCallable implements Callable {
 
                 if (response != null) {
                     if (attemptToDownloadVideo(response)) {
-                        return String.format("Successfully downloaded video for session %s from host %s");
+                        return String.format("Successfully downloaded video for session %s from host %s", this.session, this.host);
                     }
                 } else {
                     logger.info(String.format(

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/VideoRecorderCallable.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/VideoRecorderCallable.java
@@ -57,7 +57,7 @@ public class VideoRecorderCallable implements Callable {
   public String call() throws Exception {
     //Probably overkill to null these out, but i'm playing it safe until proven otherwise
     this.nodeName =
-        "Node: " + RuntimeConfig.getOS().getHostName() + " (" + RuntimeConfig.getOS().getHostIp()
+        "Node: " + RuntimeConfig.getOS().getHostName() + " (" + RuntimeConfig.getHostIp()
         + ")";
     this.lastCommand = null;
 
@@ -129,7 +129,7 @@ public class VideoRecorderCallable implements Callable {
                            .createTitleFrame(dimension, BufferedImage.TYPE_3BYTE_BGR,
                                              "Session :" + this.sessionId,
                                              "Host :" + RuntimeConfig.getOS().getHostName() + " ("
-                                             + RuntimeConfig.getOS().getHostIp() + ")",
+                                             + RuntimeConfig.getHostIp() + ")",
                                              getTimestamp().toString()),
                        0,
                        TimeUnit.NANOSECONDS);

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/videorecording/ImageToVideoConverter.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/videorecording/ImageToVideoConverter.java
@@ -100,8 +100,8 @@ public class ImageToVideoConverter implements Callable {
     String line2 = "Recorded on: ";
     String
         line3 =
-        "Encoded on: " + RuntimeConfig.getOS().getHostName() + "(" + RuntimeConfig.getOS()
-            .getHostIp() + ") at " +  new java.sql.Timestamp(
+        "Encoded on: " + RuntimeConfig.getOS().getHostName() + "(" + RuntimeConfig.getHostIp()
+                + ") at " +  new java.sql.Timestamp(
             Calendar.getInstance().getTime().getTime());
 
     BufferedImage


### PR DESCRIPTION
Probably not a real elegant approach, but the configs don't really make a distinction of the current node config.  Anyway, by default it will try to pull a "host" value from the selenium_grid_extras_config.json otherwise it checks the host value in the first node config (if it is a node) or first hub config (if it is a hub).  If nothing is found, it defaults back to OS IP value.  