### PR TITLE
Fix some issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .idea
 .iml
 .idea/*
+.classpath
+.project
+.settings
 ant-build/*
 Selenium-Grid-Extras.iml
 build/*

--- a/SeleniumGridExtras/pom.xml
+++ b/SeleniumGridExtras/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2.2</version>
+            <version>2.3</version>
         </dependency>
         <dependency>
             <groupId>net.coobird</groupId>

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/ExecuteCommand.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/ExecuteCommand.java
@@ -84,6 +84,9 @@ public class ExecuteCommand {
 
         int exitCode;
         if (waitToFinish) {
+            String output = ProcessOutputReader.getStandardOut(process);
+            String error = ProcessOutputReader.getErrorOut(process);
+
             try {
                 logger.debug("Waiting to finish");
                 exitCode = process.waitFor();
@@ -94,15 +97,7 @@ public class ExecuteCommand {
                 logger.error(message, e);
                 return jsonResponse.getJson();
             }
-        } else {
-            CommonThreadPool.startCallable(new ExecuteOsTaskCallable(cmd, process));
-            jsonResponse.addKeyValues(JsonCodec.OUT, "Background process started, check log for output");
-            return jsonResponse.getJson();
-        }
 
-        try {
-            String output = ProcessOutputReader.getStandardOut(process);
-            String error = ProcessOutputReader.getErrorOut(process);
             jsonResponse.addKeyValues(JsonCodec.EXIT_CODE, exitCode);
             jsonResponse.addKeyValues(JsonCodec.OUT, output);
             if (!error.equals("")) {
@@ -110,9 +105,10 @@ public class ExecuteCommand {
                 jsonResponse.addKeyValues(JsonCodec.ERROR, error);
             }
             return jsonResponse.getJson();
-
-        } finally {
-            process.destroy();
+        } else {
+            CommonThreadPool.startCallable(new ExecuteOsTaskCallable(cmd, process));
+            jsonResponse.addKeyValues(JsonCodec.OUT, "Background process started, check log for output");
+            return jsonResponse.getJson();
         }
     }
 }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
@@ -3,7 +3,7 @@ package com.groupon.seleniumgridextras.config;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.google.gson.internal.StringMap;
+import com.google.gson.internal.LinkedTreeMap;
 
 import com.groupon.seleniumgridextras.config.driver.ChromeDriver;
 import com.groupon.seleniumgridextras.config.driver.DriverInfo;
@@ -126,7 +126,7 @@ public class Config {
     getConfigMap().put(SETUP, new ArrayList<String>());
     getConfigMap().put(TEAR_DOWN, new ArrayList<String>());
 
-    getConfigMap().put(GRID, new StringMap());
+    getConfigMap().put(GRID, new LinkedTreeMap());
     initializeWebdriver();
     initializeIEDriver();
     initializeChromeDriver();
@@ -243,17 +243,17 @@ public class Config {
     return (List<String>) getConfigMap().get(TEAR_DOWN);
   }
 
-  public StringMap getGrid() {
-    return (StringMap) getConfigMap().get(GRID);
+  public LinkedTreeMap getGrid() {
+    return (LinkedTreeMap) getConfigMap().get(GRID);
   }
 
   public DriverInfo getIEdriver() {
     try {
       return (IEDriver) getConfigMap().get(IEDRIVER);
     } catch (ClassCastException e) {
-      StringMap
+        LinkedTreeMap
           stringMapFromGoogleWhoCantUseHashMapOnNestedObjects =
-          (StringMap) getConfigMap().get(IEDRIVER);
+          (LinkedTreeMap) getConfigMap().get(IEDRIVER);
       IEDriver ieDriver = new IEDriver();
 
       ieDriver.putAll(stringMapFromGoogleWhoCantUseHashMapOnNestedObjects);
@@ -268,9 +268,9 @@ public class Config {
     try {
       return (ChromeDriver) getConfigMap().get(CHROME_DRIVER);
     } catch (ClassCastException e) {
-      StringMap
+        LinkedTreeMap
           stringMapFromGoogleWhoCantUseHashMapOnNestedObjects =
-          (StringMap) getConfigMap().get(CHROME_DRIVER);
+          (LinkedTreeMap) getConfigMap().get(CHROME_DRIVER);
       DriverInfo chromeDriver = new ChromeDriver();
 
       chromeDriver.putAll(stringMapFromGoogleWhoCantUseHashMapOnNestedObjects);
@@ -286,9 +286,9 @@ public class Config {
     try {
       return (WebDriver) getConfigMap().get(WEBDRIVER);
     } catch (ClassCastException e) {
-      StringMap
+        LinkedTreeMap
           stringMapFromGoogleWhoCantUseHashMapOnNestedObjects =
-          (StringMap) getConfigMap().get(WEBDRIVER);
+          (LinkedTreeMap) getConfigMap().get(WEBDRIVER);
       WebDriver webDriver = new WebDriver();
 
       webDriver.putAll(stringMapFromGoogleWhoCantUseHashMapOnNestedObjects);
@@ -438,9 +438,9 @@ public class Config {
     try {
       return (Hub) getConfigMap().get(HUB_CONFIG);
     } catch (ClassCastException e) {
-      StringMap
+        LinkedTreeMap
           stringMapFromGoogleWhoCantUseHashMapOnNestedObjects =
-          (StringMap) getConfigMap().get(HUB_CONFIG);
+          (LinkedTreeMap) getConfigMap().get(HUB_CONFIG);
       Hub hubConfig = new Hub();
 
       hubConfig.putAll(stringMapFromGoogleWhoCantUseHashMapOnNestedObjects);

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridHub.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridHub.java
@@ -3,7 +3,7 @@ package com.groupon.seleniumgridextras.config;
 import com.google.common.base.Throwables;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.internal.StringMap;
+import com.google.gson.internal.LinkedTreeMap;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
@@ -122,7 +122,7 @@ public class GridHub {
         return input;
     }
 
-    public static Map stringMapToHashMap(StringMap input) {
+    public static Map linkedTreeMapToHashMap(LinkedTreeMap input) {
         Map output = new HashMap();
         output.putAll(input);
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridNode.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridNode.java
@@ -2,8 +2,7 @@ package com.groupon.seleniumgridextras.config;
 
 import com.google.common.base.Throwables;
 import com.google.gson.Gson;
-import com.google.gson.internal.StringMap;
-
+import com.google.gson.internal.LinkedTreeMap;
 import com.groupon.seleniumgridextras.config.capabilities.Capability;
 import com.groupon.seleniumgridextras.utilities.json.JsonParserWrapper;
 
@@ -50,11 +49,11 @@ public class GridNode {
                 nodeConfiguration =
                 new Gson().fromJson(configFromFile, GridNodeConfiguration.class);
 
-        List<StringMap> capabilitiesFromFile = (ArrayList<StringMap>) topLevelHash.get("capabilities");
+        List<LinkedTreeMap> capabilitiesFromFile = (ArrayList<LinkedTreeMap>) topLevelHash.get("capabilities");
 
         LinkedList<Capability> filteredCapabilities = new LinkedList<Capability>();
 
-        for (StringMap cap : capabilitiesFromFile) {
+        for (LinkedTreeMap cap : capabilitiesFromFile) {
             if (cap.containsKey("browserName")) {
                 filteredCapabilities.add(Capability.getCapabilityFor((String) cap.get("browserName"), cap));
             }
@@ -149,7 +148,7 @@ public class GridNode {
         return input;
     }
 
-    public static Map stringMapToHashMap(StringMap input) {
+    public static Map linkedTreeMapToHashMap(LinkedTreeMap input) {
         Map output = new HashMap();
         output.putAll(input);
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/homepage/HtmlNodeRenderer.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/homepage/HtmlNodeRenderer.java
@@ -2,7 +2,7 @@ package com.groupon.seleniumgridextras.homepage;
 
 import com.google.common.base.Throwables;
 import com.google.gson.JsonObject;
-import com.google.gson.internal.StringMap;
+import com.google.gson.internal.LinkedTreeMap;
 import com.groupon.seleniumgridextras.Version;
 import com.groupon.seleniumgridextras.config.GridNode;
 import com.groupon.seleniumgridextras.config.RuntimeConfig;
@@ -83,7 +83,7 @@ public class HtmlNodeRenderer {
     }
 
     protected String buildJvmMemoryInfo(Map input) {
-        StringMap<String> jvmInfoFromMap = (StringMap<String>) input.get(JsonCodec.OS.JVM.JVM_INFO);
+        LinkedTreeMap<String, String> jvmInfoFromMap = (LinkedTreeMap<String, String>) input.get(JsonCodec.OS.JVM.JVM_INFO);
         StringBuilder jvm = new StringBuilder();
 
         jvm.append("\n<ul>");
@@ -101,7 +101,7 @@ public class HtmlNodeRenderer {
     }
 
     protected String buildMemoryInfo(Map input) {
-        StringMap<String> ramFromInput = (StringMap<String>) input.get(JsonCodec.OS.Hardware.Ram.RAM);
+        LinkedTreeMap<String, String> ramFromInput = (LinkedTreeMap<String, String>) input.get(JsonCodec.OS.Hardware.Ram.RAM);
 
         StringBuilder ramInfo = new StringBuilder();
 
@@ -121,9 +121,9 @@ public class HtmlNodeRenderer {
         if (input.containsKey(JsonCodec.OS.Hardware.Processor.PROCESSOR)) {
             StringBuilder cpuInfo = new StringBuilder();
 
-            StringMap<String>
+            LinkedTreeMap<String, String>
                     cpu =
-                    (StringMap<String>) input.get(JsonCodec.OS.Hardware.Processor.PROCESSOR);
+                    (LinkedTreeMap<String, String>) input.get(JsonCodec.OS.Hardware.Processor.PROCESSOR);
 
             cpuInfo.append("\n<ul>");
             cpuInfo.append(
@@ -154,7 +154,7 @@ public class HtmlNodeRenderer {
             StringBuilder hds = new StringBuilder();
             hds.append("\n<ul>");
 
-            for (StringMap<String> currentHd : (ArrayList<StringMap<String>>) input
+            for (LinkedTreeMap<String, String> currentHd : (ArrayList<LinkedTreeMap<String, String>>) input
                     .get(JsonCodec.OS.Hardware.HardDrive.DRIVES)) {
 
                 hds.append("<li>Drive: " + currentHd.get(JsonCodec.OS.Hardware.HardDrive.DRIVE));

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/GridStatus.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/GridStatus.java
@@ -91,8 +91,8 @@ public class GridStatus extends ExecuteOSTask {
             JsonObject hubInfo = PortChecker.getParsedPortInfo(4444);
             JsonObject nodeInfo = PortChecker.getParsedPortInfo(5555);
 
-            getJsonResponse().addKeyValues(JsonCodec.WebDriver.Grid.HUB_RUNNING, hubInfo.isJsonNull() ? false : true);
-            getJsonResponse().addKeyValues(JsonCodec.WebDriver.Grid.NODE_RUNNING, nodeInfo.isJsonNull() ? false : true);
+            getJsonResponse().addKeyValues(JsonCodec.WebDriver.Grid.HUB_RUNNING, hubInfo.isJsonNull() || hubInfo.toString().equals("{}") ? false : true);
+            getJsonResponse().addKeyValues(JsonCodec.WebDriver.Grid.NODE_RUNNING, nodeInfo.isJsonNull() || nodeInfo.toString().equals("{}") ? false : true);
             getJsonResponse().addKeyValues(JsonCodec.WebDriver.Grid.HUB_INFO, hubInfo);
             getJsonResponse().addKeyValues(JsonCodec.WebDriver.Grid.NODE_INFO, nodeInfo);
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/ExecuteOsTaskCallable.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/ExecuteOsTaskCallable.java
@@ -24,7 +24,7 @@ public class ExecuteOsTaskCallable implements Callable {
 
             int exitCode = process.waitFor();
 
-            message = String.format("Command finished. \n command: %s \n exit code: %s \n standard out: \n %s \n %standard error: \n %s",
+            message = String.format("Command finished. \n command: %s \n exit code: %d \n standard out: \n %s \n standard error: \n %s",
                     this.command,
                     exitCode,
                     ProcessOutputReader.getStandardOut(process),

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/RemoteGridExtrasAsyncCallable.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/RemoteGridExtrasAsyncCallable.java
@@ -54,6 +54,7 @@ public class RemoteGridExtrasAsyncCallable implements Callable {
             );
 
             logger.error(response, e);
+            return "";
         }
         return response;
     }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/VideoDownloaderCallable.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/VideoDownloaderCallable.java
@@ -60,7 +60,9 @@ public class VideoDownloaderCallable implements Callable {
 
                 if (response != null) {
                     if (attemptToDownloadVideo(response)) {
-                        return String.format("Successfully downloaded video for session %s from host %s");
+                        return String.format("Successfully downloaded video for session %s from host %s",
+                                this.session,
+                                this.host);
                     }
                 } else {
                     logger.info(String.format(

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/videorecording/RemoteVideoRecorderHelper.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/videorecording/RemoteVideoRecorderHelper.java
@@ -32,8 +32,8 @@ public class RemoteVideoRecorderHelper {
         URI uri;
         String errorMessage = String.format("Error building URI for host: %s, port: %s, session: %s, action: %s, params: %s",
                 host,
-                session,
                 3000,
+                session,
                 JsonCodec.Video.START,
                 params.toString());
         try {
@@ -65,8 +65,8 @@ public class RemoteVideoRecorderHelper {
         URI uri;
         String errorMessage = String.format("Error building URI for host: %s, port: %s, session: %s, action: %s, params: %s",
                 host,
-                session,
                 3000,
+                session,
                 JsonCodec.Video.STOP,
                 params.toString());
         try {
@@ -84,7 +84,6 @@ public class RemoteVideoRecorderHelper {
     }
 
     public static String updateLastAction(String host, String session, String action) {
-
         URIBuilder builder = new URIBuilder();
         builder.setScheme("http");
         builder.setHost(host);

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/config/GridNodeTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/config/GridNodeTest.java
@@ -2,7 +2,7 @@ package com.groupon.seleniumgridextras.config;
 
 
 import com.google.gson.Gson;
-import com.google.gson.internal.StringMap;
+import com.google.gson.internal.LinkedTreeMap;
 
 import com.groupon.seleniumgridextras.config.capabilities.Capability;
 import com.groupon.seleniumgridextras.config.capabilities.Firefox;
@@ -138,7 +138,7 @@ public class GridNodeTest {
   public void testConfigurationProperlyWrittenToFile() throws Exception {
     Map actual = getMapFromConfigFile(fileaname);
 
-    Map actualConfiguration = GridNode.stringMapToHashMap((StringMap) actual.get("configuration"));
+    Map actualConfiguration = GridNode.linkedTreeMapToHashMap((LinkedTreeMap) actual.get("configuration"));
     actualConfiguration = GridNode.doubleToIntConverter(actualConfiguration);
     assertEquals(expectedConfiguration, actualConfiguration);
 


### PR DESCRIPTION
Hi, while learning to use Selenium Grid Extras, I found some bugs that are fixed in this PR.
Two of them are blocker for me:

- After executing dir, ps or video commands, the Grid Extras server doesn't reply to more commands.
  There is a deadlock because waitFor method was called before reading the output and error streams.

- An exception is thrown by the node when setting an implicit wait with selenium-server 2.44.0: WebDriverException: Message: For input string: "5000.0"
  It's due to a conflict with gson library, selenium 2.44.0 needs gson 2.3 and Grid Extras have 2.2.2. I've updated gson from 2.2.2 to 2.3.