### PR TITLE
Auto detect browser versions

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/ExecuteCommand.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/ExecuteCommand.java
@@ -115,4 +115,63 @@ public class ExecuteCommand {
             process.destroy();
         }
     }
+    
+    public static JsonObject execRuntime(String[] cmd, boolean waitToFinish) {
+      StringBuilder command = new StringBuilder();
+      for(String s : cmd) {
+          command.append(s + " ");
+      }
+      logger.debug("Starting to execute - " + command);
+      JsonResponseBuilder jsonResponse = new JsonResponseBuilder();
+
+      jsonResponse.addKeyDescriptions(JsonCodec.COMMAND, "Command executed");
+      jsonResponse.addKeyValues(JsonCodec.COMMAND, command.toString());
+      Process process;
+
+      try {
+          if (RuntimeConfig.getOS().isWindows()) {
+              process = Runtime.getRuntime().exec(cmd);
+          } else {
+              process = Runtime.getRuntime().exec(cmd);
+          }
+      } catch (IOException e) {
+          final String message = "Problems in running " + command + "\n" + e.toString();
+          jsonResponse.addKeyValues(JsonCodec.ERROR, message);
+          logger.warn(message);
+          return jsonResponse.getJson();
+      }
+
+      int exitCode;
+      if (waitToFinish) {
+          try {
+              logger.debug("Waiting to finish");
+              exitCode = process.waitFor();
+              logger.debug("Command Finished");
+          } catch (InterruptedException e) {
+              final String message = String.format("Interrupted running %s\n%s", command, e.getMessage());
+              jsonResponse.addKeyValues(JsonCodec.ERROR, message);
+              logger.error(message, e);
+              return jsonResponse.getJson();
+          }
+      } else {
+          CommonThreadPool.startCallable(new ExecuteOsTaskCallable(command.toString(), process));
+          jsonResponse.addKeyValues(JsonCodec.OUT, "Background process started, check log for output");
+          return jsonResponse.getJson();
+      }
+
+      try {
+          String output = ProcessOutputReader.getStandardOut(process);
+          String error = ProcessOutputReader.getErrorOut(process);
+          jsonResponse.addKeyValues(JsonCodec.EXIT_CODE, exitCode);
+          jsonResponse.addKeyValues(JsonCodec.OUT, output);
+          if (!error.equals("")) {
+              //Only add error if there is one, this way we have a nice empty array instead of [""]
+              jsonResponse.addKeyValues(JsonCodec.ERROR, error);
+          }
+          return jsonResponse.getJson();
+
+      } finally {
+          process.destroy();
+      }
+  }
 }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/browser/BrowserVersionDetector.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/browser/BrowserVersionDetector.java
@@ -1,7 +1,12 @@
 package com.groupon.seleniumgridextras.browser;
 
+import com.google.gson.JsonObject;
+import com.groupon.seleniumgridextras.ExecuteCommand;
 import com.groupon.seleniumgridextras.config.GridNode;
+import com.groupon.seleniumgridextras.config.RuntimeConfig;
 import com.groupon.seleniumgridextras.config.capabilities.Capability;
+import com.sun.jna.platform.win32.Advapi32Util;
+import com.sun.jna.platform.win32.WinReg;
 
 import java.io.File;
 import java.util.List;
@@ -12,6 +17,9 @@ public class BrowserVersionDetector {
 //  TODO: Java is not good with dynamic jar loading in way you want. Instead go with a mini grid with 1
 //  TODO: node and do all of the stuff via simple HTTP calls, CURL FTW!
 
+  private static
+  org.apache.log4j.Logger
+      logger = org.apache.log4j.Logger.getLogger(BrowserVersionDetector.class);
 
   protected File jarPath;
   protected File ieDriverPath;
@@ -87,6 +95,107 @@ public class BrowserVersionDetector {
     System.setProperty("webdriver.ie.driver", this.ieDriverPath.getAbsolutePath());
     System.setProperty("webdriver.chrome.driver", this.chromeDriverPath.getAbsolutePath());
   }
+  
+  /**
+   * 
+   * @param browserName firefox, chrome, or internetexplorer
+   * @return Browser version installed of browserName
+   */
+  public static String guessBrowserVersion(String browserName) {
+    if (browserName.equalsIgnoreCase("firefox")) {
+      return getFirefoxVersion();
+    } else if (browserName.equalsIgnoreCase("chrome")) {
+      return getChromeVersion();
+    } else if (browserName.equalsIgnoreCase("internetexplorer")) {
+      return getIEVersion();
+    } else {
+      return "";
+    }
+  }
+  
+  /**
+   * 
+   * @return version of IE installed
+   */
+  private static String getIEVersion() {
+    String regLocation = "Software\\Microsoft\\Internet Explorer";
+    String version = "";
 
+    if (RuntimeConfig.getOS().isWindows()) {
+      version = Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, regLocation, "svcVersion");
+      version = version.trim();
+      version = version.substring(0, version.indexOf('.'));
+      return version;
+    }
+    return version;
+  }
+
+  /**
+   * 
+   * @return version of Firefox installed
+   */
+  private static String getFirefoxVersion() {
+    String version = "";
+    if (RuntimeConfig.getOS().isWindows()) {
+      String[] cmd = new String[4];
+      cmd[0] = "cmd";
+      cmd[1] = "/C";
+      File f = new File("C:/Program Files (x86)");
+      if (f.exists()) {
+        cmd[2] = "C:/Program Files (x86)/Mozilla Firefox/firefox.exe";
+      } else {
+        cmd[2] = "C:/Program Files/Mozilla Firefox/firefox.exe";
+      }
+
+      cmd[3] = "--version|more";
+      JsonObject object = ExecuteCommand.execRuntime(cmd, true);
+      version = object.get("out").getAsJsonArray().get(0).getAsString().trim().replaceAll("[^\\d.]", ""); // Removes "Mozilla Firefox"
+      version = version.substring(0, version.indexOf('.'));
+      return version;
+    } else if (RuntimeConfig.getOS().isMac()) {
+      String[] cmd = {"/Applications/Firefox.app/Contents/MacOS/firefox", "--version"};
+      JsonObject object = ExecuteCommand.execRuntime(cmd, true);
+      version = object.get("out").getAsString().trim().replaceAll("[^\\d.]", ""); // Removes "Mozilla Firefox"
+      version = version.substring(0, version.indexOf('.'));
+      return version;
+    }
+    return version;
+  }
+
+  /**
+   * 
+   * @return version of Chrome installed
+   */
+  private static String getChromeVersion() {
+    String regLocation32Bit = "Software\\Google\\Chrome\\BLBeacon";
+    String regLocation64Bit = "Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Google Chrome";
+    String version = "";
+    if (RuntimeConfig.getOS().isWindows()) {
+      try {
+        version = Advapi32Util.registryGetStringValue(WinReg.HKEY_CURRENT_USER, regLocation32Bit, "version");
+      } catch (Exception e) {
+        logger.warn("Getting chrome version from " + regLocation32Bit + " failed.");
+        logger.warn(e.getMessage());
+        logger.warn("Trying " + regLocation64Bit + " next.");
+      }
+      if (version == "") { // If 1st location didn't exist, try 2nd location.
+        try {
+          version = Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, regLocation64Bit, "version");
+        } catch (Exception e) {
+          logger.warn("Getting chrome version from " + regLocation64Bit + " failed.");
+          logger.warn(e.getMessage());
+        }
+      }
+      version = version.substring(0, version.indexOf('.'));
+      return version.trim();
+    } else if (RuntimeConfig.getOS().isMac()) {
+      String[] cmd = {"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome", "--version"};
+      JsonObject object = ExecuteCommand.execRuntime(cmd, true);
+      version = object.get("out").getAsString().trim();
+      version = version.substring(0, version.indexOf('.'));
+      return version;
+    }
+    return version;
+  }
 
 }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
@@ -44,6 +44,7 @@ public class Config {
   public static final String GRID_EXTRAS_JVM_OPTIONS = "grid_extras_jvm_options";
 
   public static final String AUTO_UPDATE_DRIVERS = "auto_update_drivers";
+  public static final String AUTO_UPDATE_BROWSER_VERSIONS = "auto_update_browser_versions";
   public static final String REBOOT_AFTER_SESSIONS = "reboot_after_sessions";
 
   public static final String VIDEO_RECORDING_OPTIONS = "video_recording_options";
@@ -141,6 +142,7 @@ public class Config {
     getConfigMap().put(GRID_EXTRAS_JVM_OPTIONS, new HashMap<String, Object>());
 
     getConfigMap().put(AUTO_UPDATE_DRIVERS, "");
+    getConfigMap().put(AUTO_UPDATE_BROWSER_VERSIONS, "");
 
     getConfigMap().put(REBOOT_AFTER_SESSIONS, 0);
     initializeVideoRecorder();
@@ -163,6 +165,23 @@ public class Config {
       getConfigMap().put(AUTO_UPDATE_DRIVERS, input);
     } else {
       getConfigMap().put(AUTO_UPDATE_DRIVERS, "0");
+    }
+
+  }
+
+  public boolean getAutoUpdateBrowserVersions() {
+    if (getConfigMap().get(AUTO_UPDATE_BROWSER_VERSIONS).equals("1")) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  public void setAutoUpdateBrowserVersions(String input) {
+    if (input.equals("1")) {
+      getConfigMap().put(AUTO_UPDATE_BROWSER_VERSIONS, input);
+    } else {
+      getConfigMap().put(AUTO_UPDATE_BROWSER_VERSIONS, "0");
     }
 
   }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -37,6 +37,7 @@
 package com.groupon.seleniumgridextras.config;
 
 
+import com.groupon.seleniumgridextras.browser.BrowserVersionDetector;
 import com.groupon.seleniumgridextras.config.capabilities.Capability;
 import com.groupon.seleniumgridextras.config.remote.ConfigPusher;
 import com.groupon.seleniumgridextras.downloader.webdriverreleasemanager.WebDriverReleaseManager;
@@ -309,8 +310,9 @@ public class FirstTimeRunConfig {
             capability =
                 (Capability) Class.forName(currentCapabilityClass.getCanonicalName()).newInstance();
             capability.setPlatform(platform.toUpperCase());
-//          capability.setBrowserVersion(askQuestion(
-//              "What version of '" + capability.getBrowserName() + "' is installed?"));
+            String guessedBrowserVersion = BrowserVersionDetector.guessBrowserVersion(currentCapabilityClass.getSimpleName());
+            capability.setBrowserVersion(askQuestion(
+              "What version of '" + currentCapabilityClass.getSimpleName() + "' is installed?", guessedBrowserVersion));
 
             chosenCapabilities.add(capability);
           } catch (Exception e) {

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -323,6 +323,13 @@ public class FirstTimeRunConfig {
         }
 
       }
+
+      String answer = askQuestion("Would you like this Node to auto update browser versions?? (1-yes/0-no)", "1");
+      if (answer.equals("1")) {
+        defaultConfig.setAutoUpdateBrowserVersions("1");
+      } else {
+        defaultConfig.setAutoUpdateBrowserVersions("0");
+      }
     }
 
     return chosenCapabilities;

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/capabilities/Capability.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/capabilities/Capability.java
@@ -45,6 +45,10 @@ public abstract class Capability extends HashMap {
     this.put(BROWSER_NAME, browser);
   }
 
+  public String getBrowser() {
+    return String.valueOf(this.get(BROWSER_NAME));
+  }
+
   public static Capability getCapabilityFor(String browserName, Map capabilityMap) {
     Capability cap = getCapabilityFor(browserName);
     for (Object capabilityKey : capabilityMap.keySet()) {

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/capabilities/Capability.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/capabilities/Capability.java
@@ -27,6 +27,11 @@ public abstract class Capability extends HashMap {
     return String.valueOf(this.get(VERSION));
   }
 
+  public void setBrowserVersion(String browserVersion) {
+    this.put(VERSION, browserVersion);
+  }
+
+
   public String getMaxInstances(){
     return String.valueOf(this.get(MAX_INSTANCES));
   }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/StartGrid.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/StartGrid.java
@@ -124,23 +124,25 @@ public class StartGrid extends ExecuteOSTask {
     }
 
     // Update browser capabilities and push to remote server
-    System.out.println(UPDATING_BROWSER_VERSIONS);
-    logger.info(UPDATING_BROWSER_VERSIONS);
-    
-    java.util.List<GridNode> nodes = RuntimeConfig.getConfig().getNodes();
-    for (GridNode node : nodes) {
-      String hubHost = node.getConfiguration().getHubHost();
-      java.util.LinkedList<Capability> capabilities = node.getCapabilities();
-      for (Capability cap : capabilities) {
-        String newVersion = BrowserVersionDetector.guessBrowserVersion(cap.getBrowser());
-        if (cap.getBrowserVersion() != newVersion) {
-          cap.setBrowserVersion(newVersion);
+    if (RuntimeConfig.getConfig().getAutoUpdateBrowserVersions()) {
+      System.out.println(UPDATING_BROWSER_VERSIONS);
+      logger.info(UPDATING_BROWSER_VERSIONS);
+      
+      java.util.List<GridNode> nodes = RuntimeConfig.getConfig().getNodes();
+      for (GridNode node : nodes) {
+        String hubHost = node.getConfiguration().getHubHost();
+        java.util.LinkedList<Capability> capabilities = node.getCapabilities();
+        for (Capability cap : capabilities) {
+          String newVersion = BrowserVersionDetector.guessBrowserVersion(cap.getBrowser());
+          if (cap.getBrowserVersion() != newVersion) {
+            cap.setBrowserVersion(newVersion);
+          }
         }
-      }
-      node.writeToFile(node.getLoadedFromFile());
-      if (!RuntimeConfig.getConfig().getAutoStartHub()) {
-        if (configsDirectory.exists()) {
-          pushConfigFileToHub(hubHost, node.getLoadedFromFile());
+        node.writeToFile(node.getLoadedFromFile());
+        if (!RuntimeConfig.getConfig().getAutoStartHub()) {
+          if (configsDirectory.exists()) {
+            pushConfigFileToHub(hubHost, node.getLoadedFromFile());
+          }
         }
       }
     }


### PR DESCRIPTION
Check for browser version of IE, Firefox, and Chrome during first time run config. Add it as a String to the node config file.

Needed to add execRuntime(String[] cmd, boolean waitToFinish) to ExecuteCommand.java. I couldn't get the command (with spaces) to work otherwise, and read that using a String array works better (or easier?) than just a String.

I know you started to look at a different way to get the browser version (using a single node selenium grid I think), but that seemed like a lot more work than querying the registry or using the --version argument.

I also only handled Chrome, Firefox, and Internet Explorer on Windows and Mac (I don't have a Linux machine to verify, but should be very similar to Mac I assume). Also, I don't handle Safari (yet).

This sets up the enhancement to auto recheck the browser versions every time you start the nodes. Perhaps having an option to auto check for new browser versions or not.