### PR TITLE
Check if node before asking about video recording or creating node config file.

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -76,13 +76,17 @@ public class FirstTimeRunConfig {
     
     List<Capability> caps = getCapabilitiesFromUser(defaultConfig);
 
-    configureNodes(caps, hubHost, hubPort, defaultConfig);
-
+    if (defaultConfig.getAutoStartNode()) {
+      configureNodes(caps, hubHost, hubPort, defaultConfig);
+    }
+    
     setRebootAfterSessionLimit(defaultConfig);
 
     setDriverAutoUpdater(defaultConfig);
 
-    askToRecordVideo(defaultConfig);
+    if (defaultConfig.getAutoStartNode()) {
+      askToRecordVideo(defaultConfig);
+    }
 
     final
     String


### PR DESCRIPTION
Use defaultConfig.getAutoStartNode() to check if machine is a node, before creating the node config file, and before asking about video recording. This should fix : https://github.com/groupon/Selenium-Grid-Extras/issues/67 .