### PR TITLE
Add an option to "VideoRecordingOptions" called "download_videos_to_hub" 

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/VideoRecordingOptions.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/VideoRecordingOptions.java
@@ -12,6 +12,7 @@ public class VideoRecordingOptions extends HashMap<String, String> {
   private static final String FRAMES = "frames";
   private static final String WIDTH = "width";
   private static final String HEIGHT = "height";
+  private static final String DOWNLOAD_VIDEOS_TO_HUB = "download_videos_to_hub";
   private static final String VIDEOS_TO_KEEP = "videos_to_keep";
   private static final String VIDEO_OUTPUT_DIR = "video_output_dir";
   private static final String IDLE_VIDEO_TIMEOUT = "idle_video_timeout";
@@ -47,6 +48,14 @@ public class VideoRecordingOptions extends HashMap<String, String> {
 
   public int getHeight() {
     return Integer.valueOf(this.get(HEIGHT));
+  }
+
+  public boolean getDownloadVideosToHub() {
+    return Boolean.valueOf(this.get(DOWNLOAD_VIDEOS_TO_HUB));
+  }
+
+  public void setDownloadVideosToHub(boolean downloadVideosToHub) {
+    this.put(DOWNLOAD_VIDEOS_TO_HUB, String.valueOf(downloadVideosToHub));
   }
 
   public void setVideosToKeep(int count) {

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
@@ -39,6 +39,8 @@
 package com.groupon.seleniumgridextras.grid.proxies;
 
 import com.google.common.base.Throwables;
+import com.groupon.seleniumgridextras.config.RuntimeConfig;
+import com.groupon.seleniumgridextras.config.VideoRecordingOptions;
 import com.groupon.seleniumgridextras.grid.proxies.sessions.threads.NodeRestartCallable;
 import com.groupon.seleniumgridextras.tasks.config.TaskDescriptions;
 import com.groupon.seleniumgridextras.utilities.json.JsonCodec;
@@ -142,10 +144,13 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
         if (session.getExternalKey() != null) {
             stopVideoRecording(session);
 
+          VideoRecordingOptions videoRecordingOptions = RuntimeConfig.getConfig().getVideoRecording();
+          if (videoRecordingOptions != null && videoRecordingOptions.getDownloadVideosToHub()) {
             CommonThreadPool.startCallable(
                     new VideoDownloaderCallable(
                             session.getExternalKey().getKey(),
                             session.getSlot().getRemoteURL().getHost()));
+          }
         }
 
         CommonThreadPool.startCallable(

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
@@ -144,8 +144,9 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
         if (session.getExternalKey() != null) {
             stopVideoRecording(session);
 
-          VideoRecordingOptions videoRecordingOptions = RuntimeConfig.getConfig().getVideoRecording();
-          if (videoRecordingOptions != null && videoRecordingOptions.getDownloadVideosToHub()) {
+          if (RuntimeConfig.getConfig() != null &&
+                  RuntimeConfig.getConfig().getVideoRecording() != null &&
+                  RuntimeConfig.getConfig().getVideoRecording().getDownloadVideosToHub()) {
             CommonThreadPool.startCallable(
                     new VideoDownloaderCallable(
                             session.getExternalKey().getKey(),


### PR DESCRIPTION
so that it's possible to turn off downloading videos from nodes -> hub.
Many people (including me) have experienced that downloading videos to the hub:
* Doesn't work, the files are broken 65 KB files
* Doesn't respect the max video file limit
* Maybe we just don't want to download videos to the hub?

This commit allows us to turn off this feature until it's working, or in situations where we don't have enough disk space on the Hub.