### PR TITLE
NullPointerException bug fixed for test requests without browserName

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
@@ -142,10 +142,11 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
         Map<String, Object> cap = session.getRequestedCapabilities();
         String browser = (String) cap.get(CapabilityType.BROWSER_NAME);
 
-        if (browser.equals(BrowserType.IE) ||
-                browser.equals(BrowserType.IEXPLORE) ||
-                browser.equals(BrowserType.IE_HTA) ||
-                browser.equals(BrowserType.IEXPLORE_PROXY)) {
+        if (browser != null &&
+                (browser.equals(BrowserType.IE) ||
+                        browser.equals(BrowserType.IEXPLORE) ||
+                        browser.equals(BrowserType.IE_HTA) ||
+                        browser.equals(BrowserType.IEXPLORE_PROXY))) {
             CommonThreadPool.startCallable(
                     new RemoteGridExtrasAsyncCallable(
                             this.getRemoteHost().getHost(),


### PR DESCRIPTION
When there is no `browserName` capability in the request (e.g. testing native mobile app with appium), this will crash the after session hook.