### PR TITLE
Added the ability to add items to the hub class path

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
@@ -33,6 +33,7 @@ public class Config {
     public static final String HUB_CONFIG = "hub_config";
     public static final String NODE_CONFIG_FILES = "node_config_files";
     public static final String HUB_CONFIG_FILES = "hub_config_files";
+    public static final String HUB_ADDITIONAL_CLASSPATH = "hub_additional_classpath";
 
     public static final String GRID_JVM_OPTIONS = "grid_jvm_options";
     public static final String GRID_EXTRAS_JVM_OPTIONS = "grid_extras_jvm_options";
@@ -139,6 +140,7 @@ public class Config {
 
         initializeHubConfig();
 
+        getConfigMap().put(HUB_ADDITIONAL_CLASSPATH, new ArrayList<String>());
         getConfigMap().put(GRID_JVM_OPTIONS, new HashMap<String, Object>());
         getConfigMap().put(GRID_EXTRAS_JVM_OPTIONS, new HashMap<String, Object>());
 
@@ -577,5 +579,15 @@ public class Config {
         } else {
             return DefaultConfig.GRID_EXTRAS_AUTO_UPDATE_CHECK_INTERVAL;
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<String> getAdditionalHubConfig() {
+        return (List<String>) getConfigMap().get(HUB_ADDITIONAL_CLASSPATH);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void addHubClasspathItem(String item) {
+        ((List<String>) getConfigMap().get(HUB_ADDITIONAL_CLASSPATH)).add(item);
     }
 }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
@@ -26,6 +26,11 @@ public class GridStarter {
     command.append(RuntimeConfig.getConfig().getGridJvmOptions());
     command.append("-cp " + getOsSpecificQuote() + getGridExtrasJarFilePath());
 
+    List<String> additionalClassPathItems = RuntimeConfig.getConfig().getAdditionalHubConfig();
+    for(String additionalJarPath : additionalClassPathItems) {
+      command.append(RuntimeConfig.getOS().getPathSeparator() + additionalJarPath);
+    }
+
     String jarPath = RuntimeConfig.getOS().getPathSeparator() + getCurrentWebDriverJarPath();
 
     command.append(jarPath + getOsSpecificQuote());

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/config/ConfigFileReaderTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/config/ConfigFileReaderTest.java
@@ -8,9 +8,7 @@ import java.io.File;
 import java.nio.file.Paths;
 import java.util.*;
 
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/config/ConfigFileReaderTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/config/ConfigFileReaderTest.java
@@ -5,11 +5,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
+import java.nio.file.Paths;
+import java.util.*;
+
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 
 public class ConfigFileReaderTest {
@@ -67,5 +69,21 @@ public class ConfigFileReaderTest {
     ConfigFileReader c = new ConfigFileReader("foo.json");
     assertEquals(false, c.hasContent());
     assertEquals(new HashMap(), c.toHashMap());
+  }
+
+  @Test
+  public void testHubAdditionalClasspath() throws Exception {
+    String path = Paths.get(this.getClass().getResource("/fixtures/configs/additional_classpath.json").toURI()).toString();
+    ConfigFileReader configFileReader = new ConfigFileReader(path);
+
+    List<String> expectedClasspath = new ArrayList<String>(2);
+    expectedClasspath.add("/opt/selenium/prioritizer.jar");
+    expectedClasspath.add("/opt/selenium/lib/capabilitymatcher.jar");
+
+    List<String> actualClasspath = (List<String>) ((Map) configFileReader.toHashMap().get("theConfigMap")).get("hub_additional_classpath");
+
+    assertEquals(true, configFileReader.hasContent());
+    assertEquals(expectedClasspath.size(), actualClasspath.size());
+    assertTrue("Expected " + actualClasspath.toString() + " to contain " + expectedClasspath.toString(), expectedClasspath.containsAll(actualClasspath));
   }
 }

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/grid/GridStarterAdditionalHubClasspathTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/grid/GridStarterAdditionalHubClasspathTest.java
@@ -1,0 +1,52 @@
+package com.groupon.seleniumgridextras.grid;
+
+import com.groupon.seleniumgridextras.config.Config;
+import com.groupon.seleniumgridextras.config.RuntimeConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.fail;
+
+public class GridStarterAdditionalHubClasspathTest {
+
+    private static final String CLASSPATH_ITEM_1 = "/opt/selenium/prioritizer.jar";
+    private static final String CLASSPATH_ITEM_2 = "/opt/selenium/lib/capabilitymatcher.jar";
+
+    private final String configFileName = "grid_start_additional_hub_classpath.json";
+
+    private static final String START_HUB_BAT = "start_hub.bat";
+    private static final String GRID_HUB_LOG = "grid_hub.log";
+    private final String logFile = "foo.log";
+    private final String windowsBatchFileName = logFile.replace("log", "bat");
+
+
+    @Before
+    public void setUp(){
+        RuntimeConfig.setConfigFile(configFileName);
+        Config config = new Config();
+        config.addHubClasspathItem(CLASSPATH_ITEM_1);
+        config.addHubClasspathItem(CLASSPATH_ITEM_2);
+        config.writeToDisk(RuntimeConfig.getConfigFile());
+        RuntimeConfig.load();
+    }
+
+    @After
+    public void tearDown() {
+
+        new File(START_HUB_BAT).delete();
+        new File(GRID_HUB_LOG).delete();
+        new File(windowsBatchFileName).delete();
+        new File(configFileName).delete();
+        new File(RuntimeConfig.getConfigFile() + ".example").delete();
+    }
+
+    @Test
+    public void testAdditionalClasspathItemsArePresent() {
+        String command = GridStarter.getOsSpecificHubStartCommand(RuntimeConfig.getConfigFile(), RuntimeConfig.getOS().isWindows());
+        assert(command.contains(RuntimeConfig.getOS().getPathSeparator() + CLASSPATH_ITEM_1 + RuntimeConfig.getOS().getPathSeparator()));
+        assert(command.contains(RuntimeConfig.getOS().getPathSeparator() + CLASSPATH_ITEM_2 + RuntimeConfig.getOS().getPathSeparator()));
+    }
+}

--- a/SeleniumGridExtras/src/test/resources/fixtures/configs/additional_classpath.json
+++ b/SeleniumGridExtras/src/test/resources/fixtures/configs/additional_classpath.json
@@ -1,0 +1,117 @@
+{
+  "theConfigMap": {
+    "auto_update_browser_versions": "",
+    "log_maximum_size": "20000000",
+    "iedriver": {
+      "bit": "Win32",
+      "directory": "/tmp/webdriver/iedriver",
+      "version": "2.41.0"
+    },
+    "default_role": "hub",
+    "auto_update_drivers": "1",
+    "html_render_options": {
+      "html_footer_partial": "/footer_partial.html",
+      "main_js_file": "/bootstrap.3.2.0.min.js",
+      "primary_css_file_fallback": "https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css",
+      "html_header_file": "/header_partial.html",
+      "main_template": "/jumbotron-narrow.css",
+      "primary_css_file": "/bootstrap.3.2.0.min.css",
+      "main_js_fallback": "https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js",
+      "jquery_file": "/jquery.1.11.1.min.js",
+      "jquery_fallback": "https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js",
+      "html_nav_bar": "/nav_bar_partial.html",
+      "main_template_fallback": "http://getbootstrap.com/examples/jumbotron-narrow/jumbotron-narrow.css"
+    },
+    "http_request_timeout": 60000,
+    "video_recording_options": {
+      "frameSeconds": "1",
+      "frames": "5",
+      "videos_to_keep": "40",
+      "lower_third_background_color": "0,0,0,200",
+      "idle_video_timeout": "120",
+      "width": "1024",
+      "video_output_dir": "video_output",
+      "title_frame_font_color": "129,182,64,128",
+      "record_test_videos": "true",
+      "height": "768",
+      "lower_third_font_color": "255,255,255,255"
+    },
+    "grid_extras_release_url": "https://api.github.com/repos/groupon/Selenium-Grid-Extras/releases",
+    "hub_additional_classpath": [
+      "/opt/selenium/prioritizer.jar",
+      "/opt/selenium/lib/capabilitymatcher.jar"
+    ],
+    "reboot_after_sessions": "10",
+    "expose_directory": "shared",
+    "tear_down": [
+      "com.groupon.seleniumgridextras.tasks.MoveMouse"
+    ],
+    "webdriver": {
+      "directory": "/tmp/webdriver",
+      "version": "2.41.0"
+    },
+    "active_modules": [
+      "com.groupon.seleniumgridextras.tasks.DeleteOldLogsTask",
+      "com.groupon.seleniumgridextras.tasks.Setup",
+      "com.groupon.seleniumgridextras.tasks.Teardown",
+      "com.groupon.seleniumgridextras.tasks.MoveMouse",
+      "com.groupon.seleniumgridextras.tasks.RebootNode",
+      "com.groupon.seleniumgridextras.tasks.VideoRecorder",
+      "com.groupon.seleniumgridextras.tasks.KillAllIE",
+      "com.groupon.seleniumgridextras.tasks.KillAllFirefox",
+      "com.groupon.seleniumgridextras.tasks.KillAllChrome",
+      "com.groupon.seleniumgridextras.tasks.KillAllSafari",
+      "com.groupon.seleniumgridextras.tasks.GetProcesses",
+      "com.groupon.seleniumgridextras.tasks.KillPid",
+      "com.groupon.seleniumgridextras.tasks.Netstat",
+      "com.groupon.seleniumgridextras.tasks.Screenshot",
+      "com.groupon.seleniumgridextras.tasks.ExposeDirectory",
+      "com.groupon.seleniumgridextras.tasks.StartGrid",
+      "com.groupon.seleniumgridextras.tasks.GetInfoForPort",
+      "com.groupon.seleniumgridextras.tasks.GridStatus",
+      "com.groupon.seleniumgridextras.tasks.KillAllByName",
+      "com.groupon.seleniumgridextras.tasks.StopGrid",
+      "com.groupon.seleniumgridextras.tasks.GetConfig",
+      "com.groupon.seleniumgridextras.tasks.StopGridExtras",
+      "com.groupon.seleniumgridextras.tasks.IEProtectedMode",
+      "com.groupon.seleniumgridextras.tasks.IEMixedContent",
+      "com.groupon.seleniumgridextras.tasks.SystemInfo",
+      "com.groupon.seleniumgridextras.tasks.GetNodeConfig",
+      "com.groupon.seleniumgridextras.tasks.UpdateNodeConfig",
+      "com.groupon.seleniumgridextras.tasks.AutoUpgradeDrivers",
+      "com.groupon.seleniumgridextras.tasks.DownloadWebdriver",
+      "com.groupon.seleniumgridextras.tasks.DownloadIEDriver",
+      "com.groupon.seleniumgridextras.tasks.DownloadChromeDriver",
+      "com.groupon.seleniumgridextras.tasks.SessionHistory",
+      "com.groupon.seleniumgridextras.tasks.UpgradeGridExtrasTask"
+    ],
+    "grid_extras_auto_update": "0",
+    "hub_config_files": [],
+    "config_puller_http_timeout": 5000,
+    "auto_start_hub": "0",
+    "chromedriver": {
+      "bit": "32",
+      "directory": "/tmp/webdriver/chromedriver",
+      "version": "2.10"
+    },
+    "disabled_modules": [
+      "com.groupon.seleniumgridextras.tasks.GetFile"
+    ],
+    "grid_extras_auto_update_check_interval": "86400000",
+    "auto_start_node": "1",
+    "hub_config": {
+      "role": "hub",
+      "port": "4444",
+      "servlets": "com.groupon.seleniumgridextras.grid.servlets.ProxyStatusJsonServlet",
+      "host": "192.168.1.12"
+    },
+    "log_maximum_age_ms": 864000000,
+    "grid": {},
+    "setup": [
+      "com.groupon.seleniumgridextras.tasks.MoveMouse"
+    ],
+    "grid_jvm_options": {},
+    "node_config_files": [],
+    "grid_extras_jvm_options": {}
+  }
+}


### PR DESCRIPTION
This will resolve #94 by adding a new array field in the selenium_grid_extras.json file that allows you to specify new class path items that get passed to the hub as part of its startup.

#### Example

```json
"hub_additional_classpath": [
  "/opt/some/other/archive.jar",
  "/opt/yet/another/archive.jar"
],
```
