### PR TITLE
Fix the permission problem with rebooting a linux node

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/RebootNode.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/RebootNode.java
@@ -79,7 +79,7 @@ public class RebootNode extends ExecuteOSTask {
     @Override
     public String getLinuxCommand(String param) {
         logReboot();
-        return "shutdown -r now";
+        return "sudo shutdown -r now";
     }
 
     @Override


### PR DESCRIPTION
**Context**
I have been having a problem where the linux node doesn't restart every 10 tests (which is specified in my setting). So I tried to reboot through the REST API /reboot, but got `shutdown: Need to be root` error.

**Problem and Solution**
The problem is quite clearly stated in the error message. `shutdown` is a command that is supposed to be used for super-users as noted in the man page. We can certainly run the tests in root, but that often is not preferred, so running sudo is necessary and comply with convention. Therefore, the solution is just adding sudo before running the `shutdown` command.