### PR TITLE
Configure the bit of chromedriver

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -45,6 +45,7 @@ import com.groupon.seleniumgridextras.downloader.webdriverreleasemanager.WebDriv
 import com.groupon.seleniumgridextras.os.GridPlatform;
 import com.groupon.seleniumgridextras.utilities.FileIOUtility;
 import com.groupon.seleniumgridextras.utilities.ValueConverter;
+import com.groupon.seleniumgridextras.utilities.json.JsonCodec;
 import org.apache.log4j.Logger;
 
 import java.io.BufferedReader;
@@ -240,6 +241,8 @@ public class FirstTimeRunConfig {
         String versionOfWebDriver = manager.getWedriverLatestVersion().getPrettyPrintVersion(".");
         String versionOfIEDriver = manager.getIeDriverLatestVersion().getPrettyPrintVersion(".");
 
+        String bitOfChrome = JsonCodec.WebDriver.Downloader.BIT_32;
+
         if (answer.equals("1")) {
             defaultConfig.setAutoUpdateDrivers("1");
 
@@ -252,6 +255,8 @@ public class FirstTimeRunConfig {
                     askQuestion("What version of WebDriver Jar should we use?", versionOfWebDriver);
             versionOfChrome =
                     askQuestion("What version of Chrome Driver should we use?", versionOfChrome);
+            bitOfChrome =
+                    askQuestion("What bit of Chrome Driver should we use?", bitOfChrome);
             versionOfIEDriver =
                     askQuestion("What version of IE Driver should we use?", versionOfIEDriver);
         }
@@ -259,12 +264,15 @@ public class FirstTimeRunConfig {
         defaultConfig.getWebdriver().setVersion(versionOfWebDriver);
         defaultConfig.getIEdriver().setVersion(versionOfIEDriver);
         defaultConfig.getChromeDriver().setVersion(versionOfChrome);
+        defaultConfig.getChromeDriver().setBit(bitOfChrome);
 
         System.out
                 .println("Current Selenium Driver Version: " + defaultConfig.getWebdriver().getVersion());
         System.out.println("Current IE Driver Version: " + defaultConfig.getIEdriver().getVersion());
         System.out
                 .println("Current Chrome Driver Version: " + defaultConfig.getChromeDriver().getVersion());
+        System.out
+                .println("Current Chrome Driver Bit: " + defaultConfig.getChromeDriver().getBit());
 
     }
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/json/JsonCodec.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/json/JsonCodec.java
@@ -196,6 +196,7 @@ public class JsonCodec {
         public static class Downloader {
 
             public static final String BIT_32 = "32";
+            public static final String BIT_64 = "64";
             public static final String ROOT_DIR = "root_dir";
             public static final String BIT = "bit";
             public static final String WIN32 = "Win32";


### PR DESCRIPTION
**Context**
Currently there is no option to specify the bit of the chromedriver that the user desires to download through Selenium Grid Extras. The Linux chromedriver for example provides a 64bit version and the current implementation hardcodes the default bit to 32bit without configuration, so such configuration is needed for users who would like to achieve this.

**Solution**
The current implementation already has taken bit into account (as seen in `DriverInfo`, the base class of `ChromeDriver`) and the bit saved in this class is used to download the appropriate chromedriver in `ChromeDriverDownloader`. Therefore, the solution is to modify the part that asks user questions and generate `selenium_grid_extras.json` in order to obtain and store the bit.