### PR TITLE
Fix issue #159, where you can't pass in "-Xmx" or any option not starting with -D

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
@@ -33,6 +33,7 @@ public class Config {
     public static final String HUB_CONFIG_FILES = "hub_config_files";
 
     public static final String GRID_JVM_OPTIONS = "grid_jvm_options";
+    public static final String GRID_JVM_X_OPTIONS = "grid_jvm_x_options";
     public static final String GRID_EXTRAS_JVM_OPTIONS = "grid_extras_jvm_options";
 
     public static final String AUTO_UPDATE_DRIVERS = "auto_update_drivers";
@@ -443,6 +444,15 @@ public class Config {
     public String getGridJvmOptions() {
         logger.info(getConfigMap().get(GRID_JVM_OPTIONS));
         return mapToJvmParams((Map<String, Object>) getConfigMap().get(GRID_JVM_OPTIONS));
+    }
+
+    public String getGridJvmXOptions() {
+        logger.info(getConfigMap().get(GRID_JVM_X_OPTIONS));
+        Object options = getConfigMap().get(GRID_JVM_X_OPTIONS);
+        if (!(options instanceof String)) {
+            return ""; // If the options is null or an invalid type, just return the empty string.
+        }
+        return ((String)options).trim() + " "; // The convention is to return a string with a trailing space
     }
 
     public String getGridExtrasJvmOptions() {

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
@@ -175,6 +175,7 @@ public class GridStarter {
 
         StringBuilder command = new StringBuilder();
         command.append(getJavaExe() + " ");
+        command.append(RuntimeConfig.getConfig().getGridJvmXOptions());
         command.append(RuntimeConfig.getConfig().getGridJvmOptions());
 
         if (windows) {

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
@@ -23,6 +23,7 @@ public class GridStarter {
 
         StringBuilder command = new StringBuilder();
         command.append(getJavaExe() + " ");
+        command.append(RuntimeConfig.getConfig().getGridJvmXOptions());
         command.append(RuntimeConfig.getConfig().getGridJvmOptions());
         command.append("-cp " + getOsSpecificQuote() + getGridExtrasJarFilePath());
 


### PR DESCRIPTION
Simple fix, just allow an additional option called "grid_jvm_x_options" that allows passing in any String to the commandline. 