### PR TITLE
Delete old videos in hub before downloading a new video

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
@@ -159,10 +159,16 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
         if (session.getExternalKey() != null) {
             stopVideoRecording(session);
 
-            CommonThreadPool.startCallable(
-                    new VideoDownloaderCallable(
-                            session.getExternalKey().getKey(),
-                            session.getSlot().getRemoteURL().getHost()));
+            // Download video only if 'videos_to_keep' is greater than 0
+            if (RuntimeConfig.getConfig() == null) {
+                RuntimeConfig.load(false);
+            }
+            if (RuntimeConfig.getConfig().getVideoRecording().getVideosToKeep() > 0) {
+                CommonThreadPool.startCallable(
+                        new VideoDownloaderCallable(
+                                session.getExternalKey().getKey(),
+                                session.getSlot().getRemoteURL().getHost()));
+            }
         }
 
         CommonThreadPool.startCallable(

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/HttpUtility.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/HttpUtility.java
@@ -4,6 +4,7 @@ import com.google.common.base.Throwables;
 import com.groupon.seleniumgridextras.VideoHttpExecutor;
 import com.groupon.seleniumgridextras.config.DefaultConfig;
 import com.groupon.seleniumgridextras.config.RuntimeConfig;
+import com.groupon.seleniumgridextras.utilities.threads.video.VideoRecorderCallable;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 
@@ -73,6 +74,9 @@ public class HttpUtility {
         if (!destinationDir.exists()) {
             destinationDir.mkdir();
         }
+
+        // Delete old movies
+        VideoRecorderCallable.deleteOldMovies(destinationDir);
 
         File destFile = new File(
                 destinationDir.getAbsolutePath(),

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/VideoRecorderCallable.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/VideoRecorderCallable.java
@@ -56,7 +56,7 @@ public class VideoRecorderCallable implements Callable {
                     dimension.getWidth(),
                     dimension.getHeight()));
         }
-        deleteOldMovies();
+        VideoRecorderCallable.deleteOldMovies(outputDir);
     }
 
     @Override
@@ -249,8 +249,8 @@ public class VideoRecorderCallable implements Callable {
         return image;
     }
 
-    protected void deleteOldMovies() {
-        File[] files = outputDir.listFiles();
+    public static void deleteOldMovies(File moviesDir) {
+        File[] files = moviesDir.listFiles();
         //TODO: This is tested, but don't you dare modify this without writing a new test!
         int filesToKeep = RuntimeConfig.getConfig().getVideoRecording().getVideosToKeep();
         int currentFileCount = files.length;

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/utilities/HttpUtilityTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/utilities/HttpUtilityTest.java
@@ -48,10 +48,4 @@ public class HttpUtilityTest {
         assertEquals(200, HttpUtility.checkIfUrlStatusCode(new URL("https://github.com/groupon/Selenium-Grid-Extras/releases/download/v1.5.0/SeleniumGridExtras-1.5.0-SNAPSHOT-jar-with-dependencies.jar")));
     }
 
-//    @Test //This is commented out until we find a more consistent place to download videos from
-//    public void testGetVideoFromUri() throws Exception {
-//        RuntimeConfig.load();
-//        File actual = HttpUtility.downloadVideoFromUri(new URI("http://192.168.168.144:3000/download_video/ad895b34-ee0a-4362-b542-a63d90ea221d.mp4"));
-//        assertTrue(actual.exists());
-//    }
 }

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/utilities/HttpUtilityVideosTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/utilities/HttpUtilityVideosTest.java
@@ -1,0 +1,74 @@
+package com.groupon.seleniumgridextras.utilities;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.groupon.seleniumgridextras.config.Config;
+import com.groupon.seleniumgridextras.config.DefaultConfig;
+import com.groupon.seleniumgridextras.config.RuntimeConfig;
+
+import java.io.File;
+import java.net.URI;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+// This class is ignored until we find a more consistent place to download videos from
+@Ignore
+public class HttpUtilityVideosTest {
+
+    public static final String VIDEO_RECORDER_TEST_JSON = "video_recorder_test.json";
+
+    final private String videosUrl = "http://192.168.168.144:3000//download_video/";
+    final private String video1Filename = "e985bb1c-bb92-4b16-8e76-62e039efbbc0.mp4";
+    final private String video2Filename = "f041511c-367d-4772-a82a-7b48ab69615c.mp4";
+    final private String video3Filename = "94a74a04-1579-4475-b65d-926b905f0a40.mp4";
+
+    @Before
+    public void setUp() throws Exception {
+        RuntimeConfig.setConfigFile(VIDEO_RECORDER_TEST_JSON);
+        Config config = DefaultConfig.getDefaultConfig();
+        config.getVideoRecording().setVideosToKeep(1);
+        config.writeToDisk(RuntimeConfig.getConfigFile());
+        RuntimeConfig.load();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        delete(new File("video_output", video1Filename));
+        delete(new File("video_output", video2Filename));
+        delete(new File("video_output", video3Filename));
+        delete(new File(RuntimeConfig.getConfigFile()));
+        delete(new File(VIDEO_RECORDER_TEST_JSON + ".example"));
+    }
+
+    private void delete(File f) {
+        if (f.exists()) {
+            f.delete();
+        }
+    }
+
+    @Test
+    public void testGetVideoFromUri() throws Exception {
+        File local1 = HttpUtility.downloadVideoFromUri(new URI(videosUrl + video1Filename));
+        assertTrue(local1.exists());
+    }
+
+    @Test
+    public void testGetVideoFromUriAndDeleteOldMovies() throws Exception {
+        File video1 = HttpUtility.downloadVideoFromUri(new URI(videosUrl + video1Filename));
+        File video2 = HttpUtility.downloadVideoFromUri(new URI(videosUrl + video2Filename));
+        assertTrue(video1.exists());
+        assertTrue(video2.exists());
+
+        File video3 = HttpUtility.downloadVideoFromUri(new URI(videosUrl + video3Filename));
+
+        // Only one file has been removed because the number of files is checked before the download 
+        assertFalse(video1.exists());
+        assertTrue(video2.exists());
+        assertTrue(video3.exists());
+    }
+
+}

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/utilities/HttpUtilityVideosTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/utilities/HttpUtilityVideosTest.java
@@ -21,7 +21,7 @@ public class HttpUtilityVideosTest {
 
     public static final String VIDEO_RECORDER_TEST_JSON = "video_recorder_test.json";
 
-    final private String videosUrl = "http://192.168.168.144:3000//download_video/";
+    final private String videosUrl = "http://192.168.168.144:3000/download_video/";
     final private String video1Filename = "e985bb1c-bb92-4b16-8e76-62e039efbbc0.mp4";
     final private String video2Filename = "f041511c-367d-4772-a82a-7b48ab69615c.mp4";
     final private String video3Filename = "94a74a04-1579-4475-b65d-926b905f0a40.mp4";
@@ -37,9 +37,9 @@ public class HttpUtilityVideosTest {
 
     @After
     public void tearDown() throws Exception {
-        delete(new File("video_output", video1Filename));
-        delete(new File("video_output", video2Filename));
-        delete(new File("video_output", video3Filename));
+        delete(new File(DefaultConfig.VIDEO_OUTPUT_DIRECTORY, video1Filename));
+        delete(new File(DefaultConfig.VIDEO_OUTPUT_DIRECTORY, video2Filename));
+        delete(new File(DefaultConfig.VIDEO_OUTPUT_DIRECTORY, video3Filename));
         delete(new File(RuntimeConfig.getConfigFile()));
         delete(new File(VIDEO_RECORDER_TEST_JSON + ".example"));
     }

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/videorecording/VideoRecorderCallableTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/videorecording/VideoRecorderCallableTest.java
@@ -27,9 +27,9 @@ public class VideoRecorderCallableTest {
     final private String session2 = "654321";
     final private String session3 = "abcdef";
 
-    final private File session1File = new File("video_output", session1 + ".mp4");
-    final private File session2File = new File("video_output", session2 + ".mp4");
-    final private File session3File = new File("video_output", session3 + ".mp4");
+    final private File session1File = new File(DefaultConfig.VIDEO_OUTPUT_DIRECTORY, session1 + ".mp4");
+    final private File session2File = new File(DefaultConfig.VIDEO_OUTPUT_DIRECTORY, session2 + ".mp4");
+    final private File session3File = new File(DefaultConfig.VIDEO_OUTPUT_DIRECTORY, session3 + ".mp4");
 
     @Before
     public void setUp() throws Exception {
@@ -152,6 +152,10 @@ public class VideoRecorderCallableTest {
     @Test
     public void testDeleteOldMovies() throws Exception {
         // Create empty files
+        File outputDir = new File(DefaultConfig.VIDEO_OUTPUT_DIRECTORY);
+        if (!outputDir.exists()) {
+            outputDir.mkdir();
+        }
         session1File.createNewFile();
         Thread.sleep(100);
         session2File.createNewFile();
@@ -159,7 +163,7 @@ public class VideoRecorderCallableTest {
         session3File.createNewFile();
 
         // Delete older files
-        VideoRecorderCallable.deleteOldMovies(new File("video_output"));
+        VideoRecorderCallable.deleteOldMovies(outputDir);
 
         // Older files has been removed
         assertFalse(session1File.exists());

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/videorecording/VideoRecordingThreadPoolTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/videorecording/VideoRecordingThreadPoolTest.java
@@ -1,9 +1,12 @@
 package com.groupon.seleniumgridextras.videorecording;
 
 
+import com.groupon.seleniumgridextras.config.Config;
+import com.groupon.seleniumgridextras.config.DefaultConfig;
 import com.groupon.seleniumgridextras.config.RuntimeConfig;
 import com.groupon.seleniumgridextras.utilities.threads.video.VideoRecordingThreadPool;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -12,19 +15,31 @@ import static org.junit.Assert.assertTrue;
 
 public class VideoRecordingThreadPoolTest {
 
+    public static final String VIDEO_RECORDER_TEST_JSON = "video_recorder_test.json";
+
     final private String session1 = "123456";
     final private String session2 = "654321";
     final private String session3 = "abcdef";
 
-    final private File session1File = new File("video_output", session1 + ".mp4");
-    final private File session2File = new File("video_output", session2 + ".mp4");
-    final private File session3File = new File("video_output", session3 + ".mp4");
+    final private File session1File = new File(DefaultConfig.VIDEO_OUTPUT_DIRECTORY, session1 + ".mp4");
+    final private File session2File = new File(DefaultConfig.VIDEO_OUTPUT_DIRECTORY, session2 + ".mp4");
+    final private File session3File = new File(DefaultConfig.VIDEO_OUTPUT_DIRECTORY, session3 + ".mp4");
+
+    @Before
+    public void setUp() throws Exception {
+        RuntimeConfig.setConfigFile(VIDEO_RECORDER_TEST_JSON);
+        Config config = DefaultConfig.getDefaultConfig();
+        config.writeToDisk(RuntimeConfig.getConfigFile());
+        RuntimeConfig.load();
+    }
 
     @After
     public void tearDown() throws Exception {
         delete(session1File);
         delete(session2File);
         delete(session3File);
+        delete(new File(RuntimeConfig.getConfigFile()));
+        delete(new File(VIDEO_RECORDER_TEST_JSON + ".example"));
     }
 
     private void delete(File f) {


### PR DESCRIPTION
Delete old videos in hub before downloading a new video from any node, when there is more than 'videos_to_keep' videos in hub.
If hub is configured with "videos_to_keep": "0", the video will not be downloaded.
Fix this issue: https://github.com/groupon/Selenium-Grid-Extras/issues/92
