### PR TITLE
Issue #164 - Add an option to not download videos to the Hub, if not desired.

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/DefaultConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/DefaultConfig.java
@@ -166,6 +166,7 @@ public class DefaultConfig {
 
     private static void loadDefaultVideoRecordingOptions() {
         config.getVideoRecording().setRecordTestVideos(true);
+        config.getVideoRecording().setStoreVideosOnHub(true);  // Uploading videos to the Hub is enabled by default.
         config.getVideoRecording().setFrameRate(5, 1);
         config.getVideoRecording().setOutputDimensions(1024, 768);
         config.getVideoRecording().setVideosToKeep(VIDEOS_TO_KEEP);

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/VideoRecordingOptions.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/VideoRecordingOptions.java
@@ -52,14 +52,10 @@ public class VideoRecordingOptions extends HashMap<String, String> {
 
   public boolean getStoreVideosOnHub() {
       String option = this.get(STORE_VIDEOS_ON_HUB);
-      // Default = true
-      if (option == null) {
-          return true;
-      }
       return Boolean.valueOf(option);
   }
 
-  public void setStoreVideosOnHub(String value) {
+  public void setStoreVideosOnHub(boolean value) {
     this.put(STORE_VIDEOS_ON_HUB, String.valueOf(value));
   }
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/VideoRecordingOptions.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/VideoRecordingOptions.java
@@ -12,6 +12,7 @@ public class VideoRecordingOptions extends HashMap<String, String> {
   private static final String FRAMES = "frames";
   private static final String WIDTH = "width";
   private static final String HEIGHT = "height";
+  private static final String STORE_VIDEOS_ON_HUB = "store_videos_on_hub";
   private static final String VIDEOS_TO_KEEP = "videos_to_keep";
   private static final String VIDEO_OUTPUT_DIR = "video_output_dir";
   private static final String IDLE_VIDEO_TIMEOUT = "idle_video_timeout";
@@ -47,6 +48,19 @@ public class VideoRecordingOptions extends HashMap<String, String> {
 
   public int getHeight() {
     return Integer.valueOf(this.get(HEIGHT));
+  }
+
+  public boolean getStoreVideosOnHub() {
+      String option = this.get(STORE_VIDEOS_ON_HUB);
+      // Default = true
+      if (option == null) {
+          return true;
+      }
+      return Boolean.valueOf(option);
+  }
+
+  public void setStoreVideosOnHub(String value) {
+    this.put(STORE_VIDEOS_ON_HUB, String.valueOf(value));
   }
 
   public void setVideosToKeep(int count) {

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
@@ -156,13 +156,17 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
 
 
         // Stop and download video only if the external session has been established
-        if (session.getExternalKey() != null) {
-            stopVideoRecording(session);
+        if (RuntimeConfig.getConfig() != null &&
+            RuntimeConfig.getConfig().getVideoRecording() != null &&
+            RuntimeConfig.getConfig().getVideoRecording().getStoreVideosOnHub()) {
+            if (session.getExternalKey() != null) {
+                stopVideoRecording(session);
 
-            CommonThreadPool.startCallable(
+                CommonThreadPool.startCallable(
                     new VideoDownloaderCallable(
-                            session.getExternalKey().getKey(),
-                            session.getSlot().getRemoteURL().getHost()));
+                        session.getExternalKey().getKey(),
+                        session.getSlot().getRemoteURL().getHost()));
+            }
         }
 
         CommonThreadPool.startCallable(


### PR DESCRIPTION
Added an option "store_videos_on_hub" that defaults to true, to VideoRecordingOptions.