### PR TITLE
Starting batch files minimized

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
@@ -159,7 +159,7 @@ public class GridStarter {
 
             String batchFile = logFile.replace("log", "bat");
             writeBatchFile(batchFile, command);
-            return "start " + batchFile;
+            return "start /MIN " + batchFile;
         } else {
             return command;
         }


### PR DESCRIPTION
The batch file console for the selenium node process was consistently obscuring the browser when using Edge on Windows 10.  This should fix the problem.