### PR TITLE
Start multiple hubs on a machine

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
@@ -38,8 +38,8 @@ public class GridStarter {
         command.append(" org.openqa.grid.selenium.GridLauncher -role hub ");
 //	    command.append(RuntimeConfig.getConfig().getHub().getStartCommand()); // TODO Removed 
 
-        String
-                logCommand = " -log log" + RuntimeConfig.getOS().getFileSeparator() + "grid_hub.log";
+        String logFile = configFile.replace("json", "log");
+        String logCommand = " -log log" + RuntimeConfig.getOS().getFileSeparator() + logFile;
 
         command.append(logCommand);
 //      command.append(" -browserTimeout 120 -timeout 120"); // TODO Removed
@@ -88,26 +88,26 @@ public class GridStarter {
     }
 
     public static JsonObject startAllHubs(JsonResponseBuilder jsonResponseBuilder) {
-        List<String> configFiles = RuntimeConfig.getConfig().getHubConfigFiles();
-        String configFile = configFiles.get(0); // TODO For now just use the first config file
-        String command = getOsSpecificHubStartCommand(configFile, RuntimeConfig.getOS().isWindows());
-        logger.info(command);
+        for (String configFile : RuntimeConfig.getConfig().getHubConfigFiles()) {
+            String command = getOsSpecificHubStartCommand(configFile, RuntimeConfig.getOS().isWindows());
+            logger.info(command);
 
-        try {
-            JsonObject startResponse = ExecuteCommand.execRuntime(command, false);
-            logger.info(startResponse);
+            try {
+                JsonObject startResponse = ExecuteCommand.execRuntime(command, false);
+                logger.info(startResponse);
 
-            if (!startResponse.get(JsonCodec.EXIT_CODE).toString().equals("0")) {
-                jsonResponseBuilder
+                if (!startResponse.get(JsonCodec.EXIT_CODE).toString().equals("0")) {
+                    jsonResponseBuilder
                         .addKeyValues(JsonCodec.ERROR, "Error running " + startResponse.get(JsonCodec.ERROR).toString());
-            }
-        } catch (Exception e) {
-            jsonResponseBuilder
+                }
+            } catch (Exception e) {
+                jsonResponseBuilder
                     .addKeyValues(JsonCodec.ERROR, "Error running " + command);
-            jsonResponseBuilder
+                jsonResponseBuilder
                     .addKeyValues(JsonCodec.ERROR, e.toString());
 
-            e.printStackTrace();
+                e.printStackTrace();
+            }
         }
         return jsonResponseBuilder.getJson();
     }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/StartGrid.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/StartGrid.java
@@ -56,7 +56,7 @@ import java.util.Map;
 public class StartGrid extends ExecuteOSTask {
 
   private static final String ATTEMPTING_TO_START_GRID_NODES = "Attempting to start Grid Nodes";
-  private static final String ATTEMPTING_TO_START_GRID_HUB = "Attempting to start Grid Hub";
+  private static final String ATTEMPTING_TO_START_GRID_HUBS = "Attempting to start Grid Hubs";
   private static final
   String CANT_LAUNCH_ERROR = "Something didn't go right in launching service";
   private static final
@@ -187,7 +187,7 @@ public class StartGrid extends ExecuteOSTask {
   }
 
   private JsonObject startHub() {
-    System.out.println(ATTEMPTING_TO_START_GRID_HUB);
+    System.out.println(ATTEMPTING_TO_START_GRID_HUBS);
     return GridStarter.startAllHubs(getJsonResponse());
   }
 


### PR DESCRIPTION
I have modified GridStarter.java to start all configured hubs, not only the first one.
To configure more than one hub, you must have a json file for each hub, configured with different ports:
*hub_4444.json*
```
{
    "port": 4444,
    ...
}
```
*hub_4446.json*
```
{
    "port": 4446,
    ...
}
```
And configure selenium_grid_extras_config.json with the list of hub config files:
```
"hub_config_files": [
    "hub_4444.json",
    "hub_4446.json"
],
```
The hub log name changes from grid_hub.log to hub_4444.log and hub_4446.log

Fix these issues: https://github.com/groupon/Selenium-Grid-Extras/issues/41 and https://github.com/groupon/Selenium-Grid-Extras/issues/176