### PR TITLE
Setting bit version for IE driver on first time config

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -267,6 +267,8 @@ public class FirstTimeRunConfig {
 
         defaultConfig.getWebdriver().setVersion(versionOfWebDriver);
         defaultConfig.getIEdriver().setVersion(versionOfIEDriver);
+        defaultConfig.getIEdriver().setBit(
+                RuntimeConfig.getOS().getWindowsRealArchitecture().equals("64")? "x64" : "Win32");		
         defaultConfig.getChromeDriver().setVersion(versionOfChrome);
         defaultConfig.getChromeDriver().setBit(bitOfChrome);
 


### PR DESCRIPTION
On windows 64 bit windows machines by default it was downloading 32 bits IE driver version.