### PR TITLE
Make compatible with Selenium 3. 

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
@@ -113,8 +113,9 @@ public class Config {
     }
 
     public void loadNodeClasses() {
+        boolean isSelenium3 = RuntimeConfig.getConfig().getWebdriver().getVersion().startsWith("3.0");
         for (String filename : getNodeConfigFiles()) {
-            GridNode node = GridNode.loadFromFile(filename);
+            GridNode node = GridNode.loadFromFile(filename, isSelenium3);
             getNodes().add(node);
         }
     }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -251,6 +251,9 @@ public class FirstTimeRunConfig {
         String versionOfIEDriver = manager.getIeDriverLatestVersion().getPrettyPrintVersion(".");
 
         String bitOfChrome = JsonCodec.WebDriver.Downloader.BIT_32;
+        if(RuntimeConfig.getOS().isMac()) {
+          bitOfChrome = JsonCodec.WebDriver.Downloader.BIT_64;
+        }
 
         if (answer.equals("1")) {
             defaultConfig.setAutoUpdateDrivers("1");

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -86,24 +86,24 @@ public class FirstTimeRunConfig {
         }
         List<Capability> caps = getCapabilitiesFromUser(defaultConfig);
 
-        if (defaultConfig.getAutoStartNode()) {
-            configureNodes(caps, hubHost, hubPort, defaultConfig, nodePort);
-
-            List<Capability> appiumCaps = getAppiumCapabilitiesFromUser(defaultConfig);
-
-            if (appiumCaps.size() > 0) {
-                String appiumStartCommand = getAppiumStartCommand();
-
-                configureAppiumNodes(appiumCaps, hubHost, hubPort, appiumStartCommand, defaultConfig);
-            }
-        }
-
         setLogMaximumDaysToKeep(defaultConfig);
 
         setRebootAfterSessionLimit(defaultConfig);
         setAutoLogonAsUser(defaultConfig);
 
         setDriverAutoUpdater(defaultConfig);
+
+        if (defaultConfig.getAutoStartNode()) {
+          configureNodes(caps, hubHost, hubPort, defaultConfig, nodePort);
+
+          List<Capability> appiumCaps = getAppiumCapabilitiesFromUser(defaultConfig);
+
+          if (appiumCaps.size() > 0) {
+              String appiumStartCommand = getAppiumStartCommand();
+
+              configureAppiumNodes(appiumCaps, hubHost, hubPort, appiumStartCommand, defaultConfig);
+          }
+        }
 
         if (defaultConfig.getAutoStartNode()) {
             askToRecordVideo(defaultConfig);
@@ -302,15 +302,20 @@ public class FirstTimeRunConfig {
                 + defaultConfig.getGeckoDriver().getVersion());
 
     }
-
+    
     private static void configureNodes(List<Capability> capabilities, String hubHost,
             String hubPort, Config defaultConfig, String nodePort) {
-        GridNode node = new GridNode();
+        GridNode node = new GridNode(defaultConfig.getWebdriver().getVersion().startsWith("3.0"));
 
-        node.getConfiguration().setHubHost(hubHost);
-        node.getConfiguration().setHubPort(Integer.parseInt(hubPort));
-        node.getConfiguration().setPort(Integer.parseInt(nodePort));
-
+        if(defaultConfig.getWebdriver().getVersion().startsWith("3.0")) {
+          node.setHubHost(hubHost);
+          node.setHubPort(Integer.parseInt(hubPort));
+          node.setPort(Integer.parseInt(nodePort));
+        } else {
+          node.getConfiguration().setHubHost(hubHost);
+          node.getConfiguration().setHubPort(Integer.parseInt(hubPort));
+          node.getConfiguration().setPort(Integer.parseInt(nodePort));
+        }
         for (Capability cap : capabilities) {
             node.getCapabilities().add(cap);
         }
@@ -323,7 +328,7 @@ public class FirstTimeRunConfig {
 
     private static void configureAppiumNodes(List<Capability> capabilities, String hubHost,
                                              String hubPort, String appiumStartCommand, Config defaultConfig) {
-        GridNode node = new GridNode();
+        GridNode node = new GridNode(defaultConfig.getWebdriver().getVersion().startsWith("3.0"));
         int nodePort = 4723;
         String nodeIp = new OS().getHostIp();
         String nodeUrl = "http://" + nodeIp + ":" + nodePort + "/wd/hub";

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridNode.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridNode.java
@@ -45,6 +45,9 @@ public class GridNode {
         JsonObject topLevelJson = new JsonParser().parse(configString).getAsJsonObject();
 
         String configFromFile = topLevelJson.getAsJsonObject("configuration").toString();
+        if(RuntimeConfig.getConfig().getWebdriver().getVersion().contains("3.0")) {
+          configFromFile = topLevelJson.toString();
+        }
 
         GridNodeConfiguration
                 nodeConfiguration =
@@ -182,9 +185,7 @@ public class GridNode {
         private String hubHost;
         private String host;
         private String url;
-        private Integer registerCycle;
-        //    private int browserTimeout = 120;
-//    private int timeout = 120;
+        private Integer registerCycle = 5000;
         private int nodeStatusCheckTimeout = 10000;
         private String appiumStartCommand;
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridNode.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridNode.java
@@ -146,6 +146,14 @@ public class GridNode {
     this.hubHost = hubHost;
   }
 
+  public int getMaxSession() {
+    return this.maxSession;
+  }
+
+  public void setMaxSession(int maxSession) {
+    this.maxSession = maxSession;
+  }
+
   public String getAppiumStartCommand() {
     return appiumStartCommand;
   }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridNode.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridNode.java
@@ -23,119 +23,127 @@ import java.util.Map;
 
 public class GridNode {
 
-    private LinkedList<Capability> capabilities;
-    private GridNodeConfiguration configuration;
-    private String loadedFromFile;
+  private LinkedList<Capability> capabilities;
+  private GridNodeConfiguration configuration;
+  private String loadedFromFile;
 
-    // Selenium 3.0 has values at top level, not in "configuration"
-    private String proxy;
-    private int maxSession;
-    private int port;
-    private boolean register;
-    private int unregisterIfStillDownAfter;
-    private int hubPort;
-    private String hubHost;
-    private String host;
-    private String url;
-    private Integer registerCycle;
-    private int nodeStatusCheckTimeout;
-    private String appiumStartCommand;
+  // Selenium 3.0 has values at top level, not in "configuration"
+  private String proxy;
+  private int maxSession;
+  private int port;
+  private boolean register;
+  private int unregisterIfStillDownAfter;
+  private int hubPort;
+  private String hubHost;
+  private String host;
+  private String url;
+  private Integer registerCycle;
+  private int nodeStatusCheckTimeout;
+  private String appiumStartCommand;
 
-    //Only test the node status 1 time, since the limit checker is
-    //Since DefaultRemoteProxy.java does this check failedPollingTries >= downPollingLimit
-    private int downPollingLimit = 0;
+  //Only test the node status 1 time, since the limit checker is
+  //Since DefaultRemoteProxy.java does this check failedPollingTries >= downPollingLimit
+  private int downPollingLimit = 0;
 
-    private static Logger logger = Logger.getLogger(GridNode.class);
+  private static Logger logger = Logger.getLogger(GridNode.class);
 
-    public GridNode(boolean isSelenium3) {
-        capabilities = new LinkedList<Capability>();
-        if(!isSelenium3) { // This won't work for beta1, beta2, or beta3.
-          configuration = new GridNodeConfiguration();
-        } else {
-          proxy = "com.groupon.seleniumgridextras.grid.proxies.SetupTeardownProxy";
-          maxSession = 3;
-          register = true;
-          unregisterIfStillDownAfter = 10000;
-          registerCycle = 5000;
-          nodeStatusCheckTimeout = 10000;
-        }
+  public GridNode(boolean isSelenium3) {
+    capabilities = new LinkedList<Capability>();
+    if(!isSelenium3) { // This won't work for beta1, beta2, or beta3.
+      configuration = new GridNodeConfiguration();
+    } else {
+      proxy = "com.groupon.seleniumgridextras.grid.proxies.SetupTeardownProxy";
+      maxSession = 3;
+      register = true;
+      unregisterIfStillDownAfter = 10000;
+      registerCycle = 5000;
+      nodeStatusCheckTimeout = 10000;
+    }
+  }
+
+  private GridNode(LinkedList<Capability> caps, GridNodeConfiguration config, int hubPort, String hubHost, int nodePort) {
+    capabilities = caps;
+    if(config != null) { // If config is not null, this is Selenium 2 
+      configuration = config;
+    } else { // If config is null then hubPort, hubHost, and nodePort should be set (Selenium 3)
+      proxy = "com.groupon.seleniumgridextras.grid.proxies.SetupTeardownProxy";
+      maxSession = 3;
+      register = true;
+      unregisterIfStillDownAfter = 10000;
+      registerCycle = 5000;
+      nodeStatusCheckTimeout = 10000;
+      setHubPort(hubPort);
+      setHubHost(hubHost);
+      setPort(nodePort);
+    }
+  }
+
+  public static GridNode loadFromFile(String filename, boolean isSelenium3) {
+    String configString = readConfigFile(filename);
+    JsonObject topLevelJson = new JsonParser().parse(configString).getAsJsonObject();
+
+    String configFromFile;
+    GridNodeConfiguration nodeConfiguration = null;
+    String hubHost = null;
+    int hubPort = 0;
+    int nodePort = 0;
+    if(isSelenium3) { // This won't work for beta1, beta2, or beta3.
+      hubPort = Integer.parseInt(topLevelJson.get("hubPort").toString());
+      hubHost = topLevelJson.get("hubHost").getAsString();
+      nodePort = Integer.parseInt(topLevelJson.get("port").toString());
+    } else {
+      configFromFile = topLevelJson.getAsJsonObject("configuration").toString();
+
+      nodeConfiguration =
+          new Gson().fromJson(configFromFile, GridNodeConfiguration.class);
     }
 
-    private GridNode(LinkedList<Capability> caps, GridNodeConfiguration config, boolean isSelenium3) {
-        capabilities = caps;
-        if(!isSelenium3) { // This won't work for beta1, beta2, or beta3.
-          configuration = config;
-        } else {
-          proxy = "com.groupon.seleniumgridextras.grid.proxies.SetupTeardownProxy";
-          maxSession = 3;
-          register = true;
-          unregisterIfStillDownAfter = 10000;
-          registerCycle = 5000;
-          nodeStatusCheckTimeout = 10000;
-        }
+    LinkedList<Capability> filteredCapabilities = new LinkedList<Capability>();
+    for (JsonElement cap : topLevelJson.getAsJsonArray("capabilities")) {
+      Map capHash = JsonParserWrapper.toHashMap(cap.toString());
+      if (capHash.containsKey("browserName")) {
+        filteredCapabilities.add(Capability.getCapabilityFor((String) capHash.get("browserName"), capHash));
+      }
+
     }
 
-    public static GridNode loadFromFile(String filename, boolean isSelenium3) {
-        String configString = readConfigFile(filename);
-        JsonObject topLevelJson = new JsonParser().parse(configString).getAsJsonObject();
+    GridNode node = new GridNode(filteredCapabilities, nodeConfiguration, hubPort, hubHost, nodePort);
+    node.setLoadedFromFile(filename);
 
-        String configFromFile;
-        if(isSelenium3) { // This won't work for beta1, beta2, or beta3.
-          configFromFile = topLevelJson.toString();
-        } else {
-          configFromFile = topLevelJson.getAsJsonObject("configuration").toString();
-        }
+    return node;
+  }
 
-        GridNodeConfiguration
-                nodeConfiguration =
-                new Gson().fromJson(configFromFile, GridNodeConfiguration.class);
+  public String getLoadedFromFile() {
+    return this.loadedFromFile;
+  }
 
-        LinkedList<Capability> filteredCapabilities = new LinkedList<Capability>();
-        for (JsonElement cap : topLevelJson.getAsJsonArray("capabilities")) {
-            Map capHash = JsonParserWrapper.toHashMap(cap.toString());
-            if (capHash.containsKey("browserName")) {
-                filteredCapabilities.add(Capability.getCapabilityFor((String) capHash.get("browserName"), capHash));
-            }
+  public void setLoadedFromFile(String file) {
+    this.loadedFromFile = file;
+  }
 
-        }
-
-        GridNode node = new GridNode(filteredCapabilities, nodeConfiguration, isSelenium3);
-        node.setLoadedFromFile(filename);
-
-        return node;
-    }
-
-    public String getLoadedFromFile() {
-        return this.loadedFromFile;
-    }
-
-    public void setLoadedFromFile(String file) {
-        this.loadedFromFile = file;
-    }
-
-    // Selenium 3 requires these at the root
+  // Selenium 3 requires these at the root
   public int getPort() {
-      return port;
+    return port;
   }
 
   public void setPort(int port) {
-      this.port = port;
+    this.port = port;
   }
 
   public int getHubPort() {
-      return hubPort;
+    return hubPort;
   }
 
   public void setHubPort(int hubPort) {
-      this.hubPort = hubPort;
+    this.hubPort = hubPort;
   }
 
   public String getHubHost() {
-      return hubHost;
+    return hubHost;
   }
 
   public void setHubHost(String hubHost) {
-      this.hubHost = hubHost;
+    this.hubHost = hubHost;
   }
 
   public String getAppiumStartCommand() {
@@ -147,190 +155,189 @@ public class GridNode {
   }
 
 
-    public LinkedList<Capability> getCapabilities() {
-        return capabilities;
+  public LinkedList<Capability> getCapabilities() {
+    return capabilities;
+  }
+
+  public GridNodeConfiguration getConfiguration() {
+    return configuration;
+  }
+
+  public boolean isAppiumNode() {
+    return getLoadedFromFile().startsWith("appium");
+  }
+
+  public void writeToFile(String filename) {
+
+    try {
+      File f = new File(filename);
+      String config = this.toPrettyJsonString();
+      FileUtils.writeStringToFile(f, config);
+    } catch (Exception e) {
+      logger.fatal("Could not write node config for '" + filename + "' with following error");
+      logger.fatal(e.toString());
+      System.exit(1);
     }
 
-    public GridNodeConfiguration getConfiguration() {
-        return configuration;
-    }
 
-    public boolean isAppiumNode() {
-        return getLoadedFromFile().startsWith("appium");
-    }
+  }
 
-    public void writeToFile(String filename) {
+  private String toPrettyJsonString() {
+    return JsonParserWrapper.prettyPrintString(this);
+  }
 
+
+  protected static String readConfigFile(String filePath) {
+    String returnString = "";
+    BufferedReader reader = null;
+    try {
+      reader = new BufferedReader(new FileReader(filePath));
+      String line = null;
+      while ((line = reader.readLine()) != null) {
+        returnString = returnString + line;
+      }
+    } catch (FileNotFoundException error) {
+      String e = String.format(
+          "Error loading config from %s, %s, Will have to exit. \n%s",
+          filePath,
+          error.getMessage(),
+          Throwables.getStackTraceAsString(error));
+      System.out.println(e);
+      logger.error(e);
+
+      System.exit(1);
+    } catch (IOException error) {
+      String e = String.format(
+          "Error loading config from %s, %s, Will have to exit. \n%s",
+          filePath,
+          error.getMessage(),
+          Throwables.getStackTraceAsString(error));
+      System.out.println(e);
+      logger.error(e);
+
+      System.exit(1);
+    } finally {
+      if (reader != null) {
         try {
-            File f = new File(filename);
-            String config = this.toPrettyJsonString();
-            System.out.println("CONFIG WRITING TO FILE : " + config);
-            FileUtils.writeStringToFile(f, config);
-        } catch (Exception e) {
-            logger.fatal("Could not write node config for '" + filename + "' with following error");
-            logger.fatal(e.toString());
-            System.exit(1);
+          reader.close();
+        } catch (IOException ex) {
+          System.out.println("Error closing buffered reader");
+          logger.warn("Error closing buffered reader");
         }
+      }
+    }
+    return returnString;
+  }
 
 
+  //<Grumble Grumble>, google parsing Gson, Grumble
+  protected static Map doubleToIntConverter(Map input) {
+    for (Object key : input.keySet()) {
+
+      if (input.get(key) instanceof Double) {
+        input.put(key, ((Double) input.get(key)).intValue());
+      }
     }
 
-    private String toPrettyJsonString() {
-        return JsonParserWrapper.prettyPrintString(this);
+    return input;
+  }
+
+  public static Map linkedTreeMapToHashMap(LinkedTreeMap input) {
+    Map output = new HashMap();
+    output.putAll(input);
+
+    return output;
+  }
+
+  //</Grubmle>
+
+
+  public class GridNodeConfiguration {
+
+    private String proxy = "com.groupon.seleniumgridextras.grid.proxies.SetupTeardownProxy";
+    private int maxSession = 3;
+    private int port;
+    private boolean register = true;
+    private int unregisterIfStillDownAfter = 10000;
+    private int hubPort;
+    private String hubHost;
+    private String host;
+    private String url;
+    private Integer registerCycle = 5000;
+    private int nodeStatusCheckTimeout = 10000;
+    private String appiumStartCommand;
+
+    //Only test the node status 1 time, since the limit checker is
+    //Since DefaultRemoteProxy.java does this check failedPollingTries >= downPollingLimit
+    private int downPollingLimit = 0;
+
+
+    //java -jar 2.41.0.jar -role node -hub http://192.168.168.17:4444 -maxSession 3 -register true -unregisterIfStillDownAfter 20000 -browserTimeout 120 -timeout 120 -port
+
+    public int getMaxSession() {
+      return this.maxSession;
     }
 
-
-    protected static String readConfigFile(String filePath) {
-        String returnString = "";
-        BufferedReader reader = null;
-        try {
-            reader = new BufferedReader(new FileReader(filePath));
-            String line = null;
-            while ((line = reader.readLine()) != null) {
-                returnString = returnString + line;
-            }
-        } catch (FileNotFoundException error) {
-            String e = String.format(
-                    "Error loading config from %s, %s, Will have to exit. \n%s",
-                    filePath,
-                    error.getMessage(),
-                    Throwables.getStackTraceAsString(error));
-            System.out.println(e);
-            logger.error(e);
-
-            System.exit(1);
-        } catch (IOException error) {
-            String e = String.format(
-                    "Error loading config from %s, %s, Will have to exit. \n%s",
-                    filePath,
-                    error.getMessage(),
-                    Throwables.getStackTraceAsString(error));
-            System.out.println(e);
-            logger.error(e);
-
-            System.exit(1);
-        } finally {
-            if (reader != null) {
-                try {
-                    reader.close();
-                } catch (IOException ex) {
-                    System.out.println("Error closing buffered reader");
-                    logger.warn("Error closing buffered reader");
-                }
-            }
-        }
-        return returnString;
+    public void setMaxSession(int maxSession) {
+      this.maxSession = maxSession;
     }
 
-
-    //<Grumble Grumble>, google parsing Gson, Grumble
-    protected static Map doubleToIntConverter(Map input) {
-        for (Object key : input.keySet()) {
-
-            if (input.get(key) instanceof Double) {
-                input.put(key, ((Double) input.get(key)).intValue());
-            }
-        }
-
-        return input;
+    public int getPort() {
+      return port;
     }
 
-    public static Map linkedTreeMapToHashMap(LinkedTreeMap input) {
-        Map output = new HashMap();
-        output.putAll(input);
-
-        return output;
+    public void setPort(int port) {
+      this.port = port;
     }
 
-    //</Grubmle>
-
-
-    public class GridNodeConfiguration {
-
-        private String proxy = "com.groupon.seleniumgridextras.grid.proxies.SetupTeardownProxy";
-        private int maxSession = 3;
-        private int port;
-        private boolean register = true;
-        private int unregisterIfStillDownAfter = 10000;
-        private int hubPort;
-        private String hubHost;
-        private String host;
-        private String url;
-        private Integer registerCycle = 5000;
-        private int nodeStatusCheckTimeout = 10000;
-        private String appiumStartCommand;
-
-        //Only test the node status 1 time, since the limit checker is
-        //Since DefaultRemoteProxy.java does this check failedPollingTries >= downPollingLimit
-        private int downPollingLimit = 0;
-
-
-        //java -jar 2.41.0.jar -role node -hub http://192.168.168.17:4444 -maxSession 3 -register true -unregisterIfStillDownAfter 20000 -browserTimeout 120 -timeout 120 -port
-
-        public int getMaxSession() {
-            return this.maxSession;
-        }
-
-        public void setMaxSession(int maxSession) {
-            this.maxSession = maxSession;
-        }
-
-        public int getPort() {
-            return port;
-        }
-
-        public void setPort(int port) {
-            this.port = port;
-        }
-
-        public int getHubPort() {
-            return hubPort;
-        }
-
-        public void setHubPort(int hubPort) {
-            this.hubPort = hubPort;
-        }
-
-        public String getHubHost() {
-            return hubHost;
-        }
-
-        public void setHubHost(String hubHost) {
-            this.hubHost = hubHost;
-        }
-
-        public String getHost() {
-            return host;
-        }
-
-        public void setHost(String host) {
-            this.host = host;
-        }
-
-        public String getUrl() {
-            return url;
-        }
-
-        public void setUrl(String url) {
-            this.url = url;
-        }
-
-        public int getRegisterCycle() {
-            return registerCycle.intValue();
-        }
-
-        public void setRegisterCycle(int registerCycle) {
-            this.registerCycle = new Integer(registerCycle);
-        }
-
-        public String getAppiumStartCommand() {
-            return appiumStartCommand;
-        }
-
-        public void setAppiumStartCommand(String appiumStartCommand) {
-            this.appiumStartCommand = appiumStartCommand;
-        }
+    public int getHubPort() {
+      return hubPort;
     }
+
+    public void setHubPort(int hubPort) {
+      this.hubPort = hubPort;
+    }
+
+    public String getHubHost() {
+      return hubHost;
+    }
+
+    public void setHubHost(String hubHost) {
+      this.hubHost = hubHost;
+    }
+
+    public String getHost() {
+      return host;
+    }
+
+    public void setHost(String host) {
+      this.host = host;
+    }
+
+    public String getUrl() {
+      return url;
+    }
+
+    public void setUrl(String url) {
+      this.url = url;
+    }
+
+    public int getRegisterCycle() {
+      return registerCycle.intValue();
+    }
+
+    public void setRegisterCycle(int registerCycle) {
+      this.registerCycle = new Integer(registerCycle);
+    }
+
+    public String getAppiumStartCommand() {
+      return appiumStartCommand;
+    }
+
+    public void setAppiumStartCommand(String appiumStartCommand) {
+      this.appiumStartCommand = appiumStartCommand;
+    }
+  }
 
 }
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/downloader/WdDownloader.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/downloader/WdDownloader.java
@@ -46,7 +46,10 @@ public class WdDownloader extends Downloader {
     setDestinationFile(version + ".jar");
 
     String versionMajor = version.substring(0, version.lastIndexOf('.'));
-
+    if(version.contains("beta")) {
+      versionMajor = version.substring(0, version.lastIndexOf('.')) + version.substring(version.indexOf('-'));
+    }
+    
     setSourceURL("http://selenium-release.storage.googleapis.com/" + versionMajor
                  + "/selenium-server-standalone-" + destinationFile);
   }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
@@ -211,10 +211,15 @@ public class GridStarter {
 
     protected static String getAppiumNodeStartCommand(String configFile) {
         StringBuilder command = new StringBuilder();
-
-        GridNodeConfiguration config = GridNode.loadFromFile(configFile).getConfiguration();
-        command.append(config.getAppiumStartCommand());
-        command.append(" -p " + config.getPort());
+        if(!getWebdriverVersion().startsWith("3.")) {
+          GridNodeConfiguration config = GridNode.loadFromFile(configFile, false).getConfiguration();
+          command.append(config.getAppiumStartCommand());
+          command.append(" -p " + config.getPort());
+        } else {
+          GridNode node = GridNode.loadFromFile(configFile, true);
+          command.append(node.getAppiumStartCommand());
+          command.append(" -p " + node.getPort());
+        }
 
         String workingDirectory = System.getProperty("user.dir");
         String configFileFullPath = workingDirectory + RuntimeConfig.getOS().getFileSeparator() + configFile;

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
@@ -35,14 +35,13 @@ public class GridStarter {
         }
 
         command.append(jarPath + getOsSpecificQuote());
-        command.append(" org.openqa.grid.selenium.GridLauncher -role hub ");
-//	    command.append(RuntimeConfig.getConfig().getHub().getStartCommand()); // TODO Removed 
+        String classPath = getWebdriverVersion().startsWith("3.") ? "org.openqa.grid.selenium.GridLauncherV3" : "org.openqa.grid.selenium.GridLauncher";
+        command.append(" " + classPath + " -role hub ");
 
         String logFile = configFile.replace("json", "log");
         String logCommand = " -log log" + RuntimeConfig.getOS().getFileSeparator() + logFile;
 
         command.append(logCommand);
-//      command.append(" -browserTimeout 120 -timeout 120"); // TODO Removed
         command.append(" -hubConfig " + configFile);
 
         logger.info("Hub Start Command: \n\n" + String.valueOf(command));
@@ -174,8 +173,12 @@ public class GridStarter {
             host = " -host " + RuntimeConfig.getHostIp();
         }
 
-        if (RuntimeConfig.getOS().getHostName() != null) {
+        if ((RuntimeConfig.getOS().getHostName() != null) && 
+            !getWebdriverVersion().startsWith("3.")) { // Exception in thread "main" com.beust.jcommander.ParameterException: Unknown option: -friendlyHostName
             host = " -friendlyHostName " + RuntimeConfig.getOS().getHostName();
+        } else if ((RuntimeConfig.getOS().getHostName() != null) && 
+            getWebdriverVersion().startsWith("3.")) {
+            host = " -id " + RuntimeConfig.getOS().getHostName();
         }
 
         StringBuilder command = new StringBuilder();
@@ -198,7 +201,8 @@ public class GridStarter {
         }
         command.append(RuntimeConfig.getOS().getPathSeparator() + getCurrentWebDriverJarPath()
                 + getOsSpecificQuote());
-        command.append(" org.openqa.grid.selenium.GridLauncher -role wd ");
+        String classPath = getWebdriverVersion().startsWith("3.") ? "org.openqa.grid.selenium.GridLauncherV3" : "org.openqa.grid.selenium.GridLauncher";
+        command.append(" " + classPath + " -role wd ");
         command.append(host);
         command.append(" -nodeConfig " + configFile);
 
@@ -270,14 +274,12 @@ public class GridStarter {
     }
 
     protected static String getCurrentWebDriverJarPath() {
-        return getWebdriverHome() + RuntimeConfig.getOS().getFileSeparator() + getWebdriverVersion()
-                + ".jar";
+        return RuntimeConfig.getConfig().getWebdriver().getExecutablePath();
     }
 
     protected static String getWebdriverVersion() {
         return RuntimeConfig.getConfig().getWebdriver().getVersion();
     }
-
 
     protected static String getWebdriverHome() {
         return RuntimeConfig.getConfig().getWebdriver().getDirectory();

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/homepage/HtmlNodeRenderer.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/homepage/HtmlNodeRenderer.java
@@ -242,11 +242,15 @@ public class HtmlNodeRenderer {
         StringBuilder renderedCapabilities = new StringBuilder();
         renderedCapabilities.append("\n<ul class='capabilities'>");
         for (GridNode node : RuntimeConfig.getConfig().getNodes()) {
+            boolean isSelenium3 = RuntimeConfig.getConfig().getWebdriver().getVersion().startsWith("3.0");
+            int nodePort = isSelenium3 ? node.getPort() : node.getConfiguration().getPort();
+            int maxSession = isSelenium3 ? node.getMaxSession() : node.getConfiguration().getMaxSession();
+            
             renderedCapabilities.append("\n\t<li class='cap_node'>");
-            renderedCapabilities.append("\n\t\tNode: " + node.getConfiguration().getPort());
+            renderedCapabilities.append("\n\t\tNode: " + nodePort);
             renderedCapabilities.append("\n\t\t<ul class='node'>");
             renderedCapabilities.append("\n\t\t\t<li>Config File: " + node.getLoadedFromFile() + "</li>");
-            renderedCapabilities.append("\n\t\t\t<li>Max Sessions: " + node.getConfiguration().getMaxSession() + "</li>");
+            renderedCapabilities.append("\n\t\t\t<li>Max Sessions: " + maxSession + "</li>");
             renderedCapabilities.append("\n\t\t\t<li class='declared_browsers'>Declared Browsers: <br/> (Version / Max Instances / Driver Version)");
             renderedCapabilities.append("\n\t\t\t\t<ul class='browser_list'>");
             for (Capability cap : node.getCapabilities()) {

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/StartGrid.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/StartGrid.java
@@ -61,6 +61,8 @@ public class StartGrid extends ExecuteOSTask {
   String CANT_LAUNCH_ERROR = "Something didn't go right in launching service";
   private static final
   String UPDATING_BROWSER_VERSIONS = "Updating browser capabilities, this may take some time";
+  private static final
+  String READ_NODE_CONFIGS = "Reading node configs and updating if switching from Selenium 2 to Selenium 3 or vice versa";
   private static Logger logger = Logger.getLogger(StartGrid.class);
 
   public StartGrid() {
@@ -116,6 +118,8 @@ public class StartGrid extends ExecuteOSTask {
    * @return
    */
   private JsonObject startNodes() {
+    boolean isSelenium3 = RuntimeConfig.getConfig().getWebdriver().getVersion().startsWith("3.0");
+        
     File configsDirectory = RuntimeConfig.getConfig().getConfigsDirectory();
     if (!RuntimeConfig.getConfig().getAutoStartHub()) {
       if (configsDirectory.exists()) {
@@ -135,7 +139,7 @@ public class StartGrid extends ExecuteOSTask {
         }
 
         String hubHost;
-        if(RuntimeConfig.getConfig().getWebdriver().getVersion().startsWith("3.0")) {
+        if(isSelenium3) {
           hubHost = node.getHubHost();
         } else {
           hubHost = node.getConfiguration().getHubHost();
@@ -153,6 +157,13 @@ public class StartGrid extends ExecuteOSTask {
             pushConfigFileToHub(hubHost, node.getLoadedFromFile());
           }
         }
+      }
+    } else {
+      System.out.println(READ_NODE_CONFIGS);
+      logger.info(READ_NODE_CONFIGS);
+      java.util.List<GridNode> nodes = RuntimeConfig.getConfig().getNodes();
+      for (GridNode node : nodes) {
+        GridNode.loadFromFile(node.getLoadedFromFile(), isSelenium3);
       }
     }
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/StartGrid.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/StartGrid.java
@@ -134,7 +134,12 @@ public class StartGrid extends ExecuteOSTask {
             continue;
         }
 
-        String hubHost = node.getConfiguration().getHubHost();
+        String hubHost;
+        if(RuntimeConfig.getConfig().getWebdriver().getVersion().startsWith("3.0")) {
+          hubHost = node.getHubHost();
+        } else {
+          hubHost = node.getConfiguration().getHubHost();
+        }
         java.util.LinkedList<Capability> capabilities = node.getCapabilities();
         for (Capability cap : capabilities) {
           String newVersion = BrowserVersionDetector.guessBrowserVersion(cap.getBrowser());
@@ -142,7 +147,7 @@ public class StartGrid extends ExecuteOSTask {
             cap.setBrowserVersion(newVersion);
           }
         }
-        node.writeToFile(node.getLoadedFromFile());
+        node.writeToFile(node.getLoadedFromFile()); // TODO causing issues with missing values in node config file.
         if (!RuntimeConfig.getConfig().getAutoStartHub()) {
           if (configsDirectory.exists()) {
             pushConfigFileToHub(hubHost, node.getLoadedFromFile());

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/StartGrid.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/StartGrid.java
@@ -147,7 +147,7 @@ public class StartGrid extends ExecuteOSTask {
             cap.setBrowserVersion(newVersion);
           }
         }
-        node.writeToFile(node.getLoadedFromFile()); // TODO causing issues with missing values in node config file.
+        node.writeToFile(node.getLoadedFromFile());
         if (!RuntimeConfig.getConfig().getAutoStartHub()) {
           if (configsDirectory.exists()) {
             pushConfigFileToHub(hubHost, node.getLoadedFromFile());

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/config/GridNodeTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/config/GridNodeTest.java
@@ -41,6 +41,7 @@ public class GridNodeTest {
     expectedConfiguration.put("maxSession", 3);
     expectedConfiguration.put("port", 5555);
     expectedConfiguration.put("register", true);
+    expectedConfiguration.put("registerCycle", 5000);
 //    expectedConfiguration.put("browserTimeout", 120);
 //    expectedConfiguration.put("timeout", 120);
     expectedConfiguration.put("hubPort", 4444);
@@ -54,7 +55,7 @@ public class GridNodeTest {
     expectedFirefoxCapability.put("version", "12");
     expectedCapabilities.add(expectedFirefoxCapability);
 
-    node = new GridNode();
+    node = new GridNode(false);
     node.getConfiguration().setHubHost("google.com");
     node.getConfiguration().setHubPort(4444);
     node.getConfiguration().setPort(5555);
@@ -82,8 +83,8 @@ public class GridNodeTest {
 
   @Test
   public void testCreateNodeFromFile() throws Exception {
-
-    GridNode nodeFromFile = GridNode.loadFromFile(fileaname);
+    boolean isSelenium3 = false;
+    GridNode nodeFromFile = GridNode.loadFromFile(fileaname, isSelenium3);
 
     assertEquals(1, nodeFromFile.getCapabilities().size());
     assertEquals(expectedCapabilities, nodeFromFile.getCapabilities());

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/grid/GridStarterTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/grid/GridStarterTest.java
@@ -60,9 +60,9 @@ public class GridStarterTest {
         Config config = new Config();
         config.getWebdriver().setVersion("1.1.1");
 
-        GridNode node1 = new GridNode();
-        GridNode node2 = new GridNode();
-        GridNode nodeAppium = new GridNode();
+        GridNode node1 = new GridNode(false);
+        GridNode node2 = new GridNode(false);
+        GridNode nodeAppium = new GridNode(false);
         nodeAppium.getConfiguration().setAppiumStartCommand("appium");
         nodeAppium.getConfiguration().setPort(4723);
 


### PR DESCRIPTION
Default to 64bit for Chromedriver for MAC as well.
During FirstTimeRunConfig, answer `0` for the question `Would you like WebDriver, IEDriver, ChromeDriver and GeckoDriver to auto update (1-yes/0-no)`
That will let you enter a version of selenium webdriver, and enter `3.0.0-beta4`.

Each time the nodes start, it will read the node config file and check if you are changing from Selenium 2 to Selenium 3 (or vice-versa) (checks the webdriver version in the grid extras config file). If you are, it fixes the node config file format.