### PR TITLE
Allow spaces in paths. Fix test cleanup for a few tests. Make GridSta…

### DIFF
--- a/SeleniumGridExtras/pom.xml
+++ b/SeleniumGridExtras/pom.xml
@@ -39,11 +39,10 @@
             <artifactId>apache-log4j-extras</artifactId>
             <version>1.2.17</version>
         </dependency>
-        <dependency> <!-- Needed for two VideoRecorderCallableTests, but can't see how -->
+        <dependency> <!-- Needed for two VideoRecorderCallable -->
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.7</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/GridStarter.java
@@ -171,7 +171,7 @@ public class GridStarter {
         sb.append(part + " ");
       }
       writeBatchFile(batchFile, sb.toString());
-      return new ArrayList<String> ( Arrays.asList ( "start" , "/MIN" , batchFile ) );
+      return new ArrayList<String> ( Arrays.asList ( "cmd", "/C", "start" , "/MIN" , batchFile ) );
     } else {
       return command;
     }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/SelfHealingGrid.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/SelfHealingGrid.java
@@ -7,6 +7,8 @@ import com.groupon.seleniumgridextras.config.Config;
 import com.groupon.seleniumgridextras.config.GridNode;
 import com.groupon.seleniumgridextras.config.RuntimeConfig;
 
+import java.util.List;
+
 import org.apache.log4j.Logger;
 
 public class SelfHealingGrid extends GridStarter {
@@ -39,9 +41,9 @@ public class SelfHealingGrid extends GridStarter {
         logger.debug(logFile);
         String configFile = node.getLoadedFromFile();
         logger.debug(configFile);
-        String startCommand = getNodeStartCommand(configFile, isWindows);
+        List<String> startCommand = getNodeStartCommand(configFile, isWindows, config);
         logger.debug(startCommand);
-        String backgroundCommand = getBackgroundStartCommandForNode(startCommand,logFile, isWindows);
+        List<String> backgroundCommand = getBackgroundStartCommandForNode(startCommand,logFile, isWindows);
         logger.debug(backgroundCommand);
 
         logger.debug(startOneNode(backgroundCommand));

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/UpgradeGridExtrasTask.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/UpgradeGridExtrasTask.java
@@ -86,7 +86,7 @@ public class UpgradeGridExtrasTask extends ExecuteOSTask {
             shellFile = new File(gridExtrasHome, startGridExtrasShellFileName + ".sh");
         }
 
-        String startCommand = String.format("%s %s -jar '%s'",
+        String startCommand = String.format("%s %s -jar \"%s\"",
                 shellFileHeader,
                 javaPath,
                 jarFile);

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/downloader/GeckoDriverDownloaderTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/downloader/GeckoDriverDownloaderTest.java
@@ -39,12 +39,12 @@ public class GeckoDriverDownloaderTest {
     new File(RuntimeConfig.getConfigFile()).delete();
     new File(RuntimeConfig.getConfigFile() + ".example").delete();
     String EXPECTED_FILENAME = "geckodriver";
-    String EXPECTED_FILENAME_COMPRESSED = "geckodriver" + VERSION + ".gz";
+    String EXPECTED_FILENAME_COMPRESSED = "geckodriver_" + VERSION + ".tar";
     if(RuntimeConfig.getOS().isWindows()) {
       EXPECTED_FILENAME = "geckodriver_" + VERSION + ".exe";
       EXPECTED_FILENAME_COMPRESSED = "geckodriver_" + VERSION + ".zip";
     } else {
-      String EXPECTED_FILENAME_COMPRESSED2 = "geckodriver" + VERSION + ".tar.gz";
+      String EXPECTED_FILENAME_COMPRESSED2 = "geckodriver_" + VERSION + ".tar.gz";
       new File(testDir, EXPECTED_FILENAME_COMPRESSED2).delete();
     }
     new File(testDir, EXPECTED_FILENAME).delete();

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/grid/GridStarterAdditionalHubClasspathTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/grid/GridStarterAdditionalHubClasspathTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 
 public class GridStarterAdditionalHubClasspathTest {
 
@@ -22,11 +22,12 @@ public class GridStarterAdditionalHubClasspathTest {
     private final String logFile = "foo.log";
     private final String windowsBatchFileName = logFile.replace("log", "bat");
 
-
+    private Config config;
+    
     @Before
     public void setUp(){
         RuntimeConfig.setConfigFile(configFileName);
-        Config config = new Config();
+        config = new Config();
         config.addHubClasspathItem(CLASSPATH_ITEM_1);
         config.addHubClasspathItem(CLASSPATH_ITEM_2);
         config.writeToDisk(RuntimeConfig.getConfigFile());
@@ -45,8 +46,12 @@ public class GridStarterAdditionalHubClasspathTest {
 
     @Test
     public void testAdditionalClasspathItemsArePresent() {
-        String command = GridStarter.getOsSpecificHubStartCommand(RuntimeConfig.getConfigFile(), RuntimeConfig.getOS().isWindows());
-        assert(command.contains(RuntimeConfig.getOS().getPathSeparator() + CLASSPATH_ITEM_1 + RuntimeConfig.getOS().getPathSeparator()));
-        assert(command.contains(RuntimeConfig.getOS().getPathSeparator() + CLASSPATH_ITEM_2 + RuntimeConfig.getOS().getPathSeparator()));
+        String[] command = GridStarter.getOsSpecificHubStartCommand(configFileName, RuntimeConfig.getOS().isWindows());
+        StringBuilder sb = new StringBuilder();
+        for(String part : command) {
+          sb.append(part + " ");
+        }
+        assertTrue(sb.toString().contains(RuntimeConfig.getOS().getPathSeparator() + CLASSPATH_ITEM_1 + RuntimeConfig.getOS().getPathSeparator()));
+        assertTrue(sb.toString().contains(RuntimeConfig.getOS().getPathSeparator() + CLASSPATH_ITEM_2 + RuntimeConfig.getOS().getPathSeparator()));
     }
 }

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/grid/GridStarterAdditionalNodeClasspathTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/grid/GridStarterAdditionalNodeClasspathTest.java
@@ -5,8 +5,10 @@ import com.groupon.seleniumgridextras.config.RuntimeConfig;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.List;
 
 public class GridStarterAdditionalNodeClasspathTest {
 
@@ -21,12 +23,15 @@ public class GridStarterAdditionalNodeClasspathTest {
     private final String windowsBatchFileName = logFile.replace("log", "bat");
 
 
+    private Config config;
+    
     @Before
     public void setUp(){
         RuntimeConfig.setConfigFile(configFileName);
-        Config config = new Config();
+        config = new Config();
         config.addNodeClasspathItem(CLASSPATH_ITEM_1);
         config.addNodeClasspathItem(CLASSPATH_ITEM_2);
+        config.getWebdriver().setVersion("3.0.1");
         config.writeToDisk(RuntimeConfig.getConfigFile());
         RuntimeConfig.load();
     }
@@ -43,8 +48,12 @@ public class GridStarterAdditionalNodeClasspathTest {
 
     @Test
     public void testAdditionalClasspathItemsArePresent() {
-        String command = GridStarter.getWebNodeStartCommand(RuntimeConfig.getConfigFile(), RuntimeConfig.getOS().isWindows());
-        assert(command.contains(RuntimeConfig.getOS().getPathSeparator() + CLASSPATH_ITEM_1 + RuntimeConfig.getOS().getPathSeparator()));
-        assert(command.contains(RuntimeConfig.getOS().getPathSeparator() + CLASSPATH_ITEM_2 + RuntimeConfig.getOS().getPathSeparator()));
+        List<String> command = GridStarter.getWebNodeStartCommand(configFileName, RuntimeConfig.getOS().isWindows(), config);
+        StringBuilder sb = new StringBuilder();
+        for(String part : command) {
+          sb.append(part + " ");
+        }
+        assertTrue(sb.toString().contains(RuntimeConfig.getOS().getPathSeparator() + CLASSPATH_ITEM_1 + RuntimeConfig.getOS().getPathSeparator()));
+        assertTrue(sb.toString().contains(RuntimeConfig.getOS().getPathSeparator() + CLASSPATH_ITEM_2 + RuntimeConfig.getOS().getPathSeparator()));
     }
 }

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/grid/GridStarterTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/grid/GridStarterTest.java
@@ -136,7 +136,7 @@ public class GridStarterTest {
         cmd.clear();
         cmd.add(command);
         List<String> backgroundStartCmdWindows = GridStarter.getBackgroundStartCommandForNode(cmd, logFile, true);
-        assertEquals("start /MIN " + windowsBatchFileName + " ", convertCommandToString(backgroundStartCmdWindows));
+        assertEquals("cmd /C start /MIN " + windowsBatchFileName + " ", convertCommandToString(backgroundStartCmdWindows));
 
         cmd.clear();
         cmd.add(command);        
@@ -150,7 +150,7 @@ public class GridStarterTest {
         cmd.clear();
         cmd.add(command);
         List<String> backgroundStartCmdAppiumWindows = GridStarter.getBackgroundStartCommandForNode(cmd, appiumLogFile, true);
-        assertEquals("start /MIN " + windowsAppiumBatchFileName + " ", convertCommandToString(backgroundStartCmdAppiumWindows));
+        assertEquals("cmd /C start /MIN " + windowsAppiumBatchFileName + " ", convertCommandToString(backgroundStartCmdAppiumWindows));
 
         cmd.clear();
         cmd.add(command);
@@ -222,9 +222,9 @@ public class GridStarterTest {
         Config config = new Config();
         config.getChromeDriver().setDirectory("/tmp/webdriver/chromedriver");
         if (RuntimeConfig.getOS().isWindows()) {
-            assertTrue(GridStarter.getChromeDriverExecutionPathParam(config).contains("-Dwebdriver.chrome.driver=\"\\tmp\\webdriver\\chromedriver\\chromedriver_"));
+            assertTrue(GridStarter.getChromeDriverExecutionPathParam(config).contains("-Dwebdriver.chrome.driver=\\tmp\\webdriver\\chromedriver\\chromedriver_"));
         } else {
-            assertTrue(GridStarter.getChromeDriverExecutionPathParam(config).contains("-Dwebdriver.chrome.driver=\"/tmp/webdriver/chromedriver/chromedriver_"));
+            assertTrue(GridStarter.getChromeDriverExecutionPathParam(config).contains("-Dwebdriver.chrome.driver=/tmp/webdriver/chromedriver/chromedriver_"));
         }
     }
 

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/grid/GridStarterTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/grid/GridStarterTest.java
@@ -13,11 +13,11 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertTrue;
 
 public class GridStarterTest {
@@ -36,14 +36,14 @@ public class GridStarterTest {
     private final
     String
             expectedCommand =
-            command + " -log log" + RuntimeConfig.getOS().getFileSeparator() + logFile;
+            command + " -log log" + RuntimeConfig.getOS().getFileSeparator() + logFile + " ";
 
     private final String appiumLogFile = "appium_foo.log";
     private final String windowsAppiumBatchFileName = appiumLogFile.replace("log", "bat");
     String
             expectedAppiumCommand =
             command + " --log " + System.getProperty("user.dir") + RuntimeConfig.getOS().getFileSeparator()
-                    + "log" + RuntimeConfig.getOS().getFileSeparator() + appiumLogFile;
+                    + "log" + RuntimeConfig.getOS().getFileSeparator() + appiumLogFile + " ";
 
 
     //COMPILED WITH USE OF http://gskinner.com/RegExr/ Use it, it will make your life simpler
@@ -97,43 +97,76 @@ public class GridStarterTest {
     @Test
     public void testGetNodeStartCommand() throws Exception {
 
-        String startCommand = GridStarter.getNodeStartCommand(nodeOneConfig, false);
-        assertThat(startCommand, containsString("org.openqa.grid.selenium.GridLauncher"));
-        assertThat(startCommand, containsString("-role wd"));
-        assertThat(startCommand, containsString("-nodeConfig " + nodeOneConfig));
+        List<String> startCommand = GridStarter.getNodeStartCommand(nodeOneConfig, false, RuntimeConfig.getConfig());
+        StringBuilder sb1 = new StringBuilder();
+        for(String part : startCommand) {
+          sb1.append(part + " ");
+        }
+        assertTrue(sb1.toString().contains("org.openqa.grid.selenium.GridLauncher"));
+        assertTrue(sb1.toString().contains("-role node"));
+        assertTrue(sb1.toString().contains("-nodeConfig " + nodeOneConfig));
 
-        startCommand = GridStarter.getNodeStartCommand(nodeAppiumConfig, false);
-        assertThat(startCommand, containsString("appium -p 4723"));
-        assertThat(startCommand, containsString("--nodeconfig " + System.getProperty("user.dir")
+        startCommand = GridStarter.getNodeStartCommand(nodeAppiumConfig, false, RuntimeConfig.getConfig());
+        StringBuilder sb2 = new StringBuilder();
+        for(String part : startCommand) {
+          sb2.append(part + " ");
+        }
+        assertTrue(sb2.toString().contains("appium -p 4723"));
+        assertTrue(sb2.toString().contains("--nodeconfig " + System.getProperty("user.dir")
                 + RuntimeConfig.getOS().getFileSeparator() + nodeAppiumConfig));
 
-        startCommand = GridStarter.getNodeStartCommand(nodeAppiumConfig, true);
-        assertThat(startCommand, containsString("appium -p 4723"));
-        assertThat(startCommand, containsString("--nodeconfig " + System.getProperty("user.dir")
+        startCommand = GridStarter.getNodeStartCommand(nodeAppiumConfig, true, RuntimeConfig.getConfig());
+        StringBuilder sb3 = new StringBuilder();
+        for(String part : startCommand) {
+          sb3.append(part + " ");
+        }
+        assertTrue(sb3.toString().contains("appium -p 4723"));
+        assertTrue(sb3.toString().contains("--nodeconfig " + System.getProperty("user.dir")
                 + RuntimeConfig.getOS().getFileSeparator() + nodeAppiumConfig));
     }
 
     @Test
     public void testGetBackgroundStartCommandForNode() throws Exception {
+        List<String> cmd = new ArrayList<String>();
+        cmd.add(command);
+        List<String> backgroundStartCmdNonWindows = GridStarter.getBackgroundStartCommandForNode(cmd, logFile, false);
 
-        assertEquals(expectedCommand,
-                GridStarter.getBackgroundStartCommandForNode(command, logFile, false));
+        assertEquals(expectedCommand, convertCommandToString(backgroundStartCmdNonWindows));
 
-        assertEquals("start /MIN " + windowsBatchFileName,
-                GridStarter.getBackgroundStartCommandForNode(command, logFile, true));
+        cmd.clear();
+        cmd.add(command);
+        List<String> backgroundStartCmdWindows = GridStarter.getBackgroundStartCommandForNode(cmd, logFile, true);
+        assertEquals("start /MIN " + windowsBatchFileName + " ", convertCommandToString(backgroundStartCmdWindows));
 
+        cmd.clear();
+        cmd.add(command);        
         assertEquals(expectedCommand, readFile(windowsBatchFileName));
 
-        assertEquals(expectedAppiumCommand,
-                GridStarter.getBackgroundStartCommandForNode(command, appiumLogFile, false));
+        cmd.clear();
+        cmd.add(command);
+        List<String> backgroundStartCmdAppiumNonWindows = GridStarter.getBackgroundStartCommandForNode(cmd, appiumLogFile, false);
+        assertEquals(expectedAppiumCommand, convertCommandToString(backgroundStartCmdAppiumNonWindows));
+        
+        cmd.clear();
+        cmd.add(command);
+        List<String> backgroundStartCmdAppiumWindows = GridStarter.getBackgroundStartCommandForNode(cmd, appiumLogFile, true);
+        assertEquals("start /MIN " + windowsAppiumBatchFileName + " ", convertCommandToString(backgroundStartCmdAppiumWindows));
 
-        assertEquals("start /MIN " + windowsAppiumBatchFileName,
-                GridStarter.getBackgroundStartCommandForNode(command, appiumLogFile, true));
-
+        cmd.clear();
+        cmd.add(command);
         assertEquals(expectedAppiumCommand, readFile(windowsAppiumBatchFileName));
 
     }
 
+    private String convertCommandToString(List<String> command) {
+      StringBuilder sb = new StringBuilder();
+      
+      for(String part : command) {
+        sb.append(part + " ");
+      }
+      
+      return sb.toString();
+    }
 
     //  @Test
 //  public void testGetOsSpecificHubStartCommandForLinux() throws Exception {
@@ -179,16 +212,19 @@ public class GridStarterTest {
 
     @Test
     public void testEdgeDriverDString() throws Exception {
-        assertEquals(" -Dwebdriver.edge.driver=\"C:\\Program Files (x86)\\Microsoft Web Driver\\MicrosoftWebDriver.exe\"",
-                GridStarter.getEdgeDriverExecutionPathParam());
+        Config config = new Config();
+        assertEquals("-Dwebdriver.edge.driver=\"C:\\Program Files (x86)\\Microsoft Web Driver\\MicrosoftWebDriver.exe\"",
+                GridStarter.getEdgeDriverExecutionPathParam(config));
     }
 
     @Test
     public void testChromeDriverDString() throws Exception {
+        Config config = new Config();
+        config.getChromeDriver().setDirectory("/tmp/webdriver/chromedriver");
         if (RuntimeConfig.getOS().isWindows()) {
-            assertTrue(GridStarter.getChromeDriverExecutionPathParam().contains("-Dwebdriver.chrome.driver=\\tmp\\webdriver\\chromedriver\\chromedriver_"));
+            assertTrue(GridStarter.getChromeDriverExecutionPathParam(config).contains("-Dwebdriver.chrome.driver=\"\\tmp\\webdriver\\chromedriver\\chromedriver_"));
         } else {
-            assertTrue(GridStarter.getChromeDriverExecutionPathParam().contains("-Dwebdriver.chrome.driver=/tmp/webdriver/chromedriver/chromedriver_"));
+            assertTrue(GridStarter.getChromeDriverExecutionPathParam(config).contains("-Dwebdriver.chrome.driver=\"/tmp/webdriver/chromedriver/chromedriver_"));
         }
     }
 

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/videorecording/VideoRecorderCallableTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/videorecording/VideoRecorderCallableTest.java
@@ -45,6 +45,7 @@ public class VideoRecorderCallableTest {
         delete(session1File);
         delete(session2File);
         delete(session3File);
+        delete(new File(DefaultConfig.VIDEO_OUTPUT_DIRECTORY));
         delete(new File(RuntimeConfig.getConfigFile()));
         delete(new File(VIDEO_RECORDER_TEST_JSON + ".example"));
     }


### PR DESCRIPTION
Make GridStarter.java more testable by passing in Config.

I use the String array to start the grid hub and node, which makes it easier to have spaces in the path names. As I was testing this, github was down, so I could not build the project. Because of this, I added Config as a parameter to GridStarter. This makes it easier to test I think.