### PR TITLE
Added configurable parameter to can decide if a node shall be unregistered during reboot or only marked as taken down

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/Config.java
@@ -43,6 +43,7 @@ public class Config {
     public static final String AUTO_UPDATE_DRIVERS = "auto_update_drivers";
     public static final String AUTO_UPDATE_BROWSER_VERSIONS = "auto_update_browser_versions";
     public static final String REBOOT_AFTER_SESSIONS = "reboot_after_sessions";
+    public static final String UNREGISTER_NODE_DURING_REBOOT = "unregisterNodeDuringReboot";
 
     public static final String VIDEO_RECORDING_OPTIONS = "video_recording_options";
     public static final String HTTP_REQUEST_TIMEOUT = "http_request_timeout";
@@ -155,6 +156,7 @@ public class Config {
         getConfigMap().put(AUTO_UPDATE_BROWSER_VERSIONS, "");
 
         getConfigMap().put(REBOOT_AFTER_SESSIONS, 0);
+        getConfigMap().put(UNREGISTER_NODE_DURING_REBOOT, "true");
         initializeVideoRecorder();
         getConfigMap().put(HTML_RENDER_OPTIONS, new HtmlConfig());
 
@@ -569,6 +571,14 @@ public class Config {
 
     public int getRebootAfterSessions() {
         return Integer.valueOf((String) getConfigMap().get(REBOOT_AFTER_SESSIONS));
+    }
+    
+    public void setUnregisterNodeDuringReboot(String unregisterNodeDuringReboot) {
+        getConfigMap().put(UNREGISTER_NODE_DURING_REBOOT, unregisterNodeDuringReboot);
+    }
+
+    public boolean getUnregisterNodeDuringReboot() {
+        return Boolean.valueOf((String) getConfigMap().get(UNREGISTER_NODE_DURING_REBOOT));
     }
 
     public File getConfigsDirectory() {

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/DefaultConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/DefaultConfig.java
@@ -48,6 +48,7 @@ public class DefaultConfig {
 
     public static final String VIDEO_OUTPUT_DIRECTORY = "video_output";
     public static final String REBOOT_AFTER_THIS_MANY_SESSIONS = "10";
+    public static final String UNREGISTER_NODE_DURING_REBOOT = "true";
     public static final String DEFAULT_HUB_PORT = "4444";
     public static final String DEFAULT_SHARED_DIRECTORY = "shared";
 
@@ -108,6 +109,7 @@ public class DefaultConfig {
         loadSharedDir();
         setAutoUpdateDrivers(JsonCodec.TRUE_INT);
         setRebootAfterSessionCount(REBOOT_AFTER_THIS_MANY_SESSIONS);
+        setUnregisterNodeDuringReboot(UNREGISTER_NODE_DURING_REBOOT);
         loadDefaultVideoRecordingOptions();
         loadHTTPOptions();
         loadHtmlRenderOptions();
@@ -341,5 +343,7 @@ public class DefaultConfig {
         config.setRebootAfterSessions(sessionCount);
     }
 
-
+    public static void setUnregisterNodeDuringReboot(String unregisterNodeDuringReboot) {
+        config.setUnregisterNodeDuringReboot(unregisterNodeDuringReboot);
+    }
 }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -246,7 +246,7 @@ public class FirstTimeRunConfig {
             String
                     answer =
                     askQuestion(
-                    		"Would you like to unregister the node during reboot. If answer is no the node will be only marked as down. (1-yes/0-no)", "1");
+                    		"Would you like to unregister the node during reboot immediately so test clients will get an error if they try to connect. Otherwise the node will be only marked as down and test clients are stored in a queue until node is up again. (1-yes/0-no)", "1");
 
             if (answer.equals("1")) {
                 defaultConfig.setUnregisterNodeDuringReboot("true");

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -90,6 +90,7 @@ public class FirstTimeRunConfig {
         setLogMaximumDaysToKeep(defaultConfig);
 
         setRebootAfterSessionLimit(defaultConfig);
+        setUnregisterNodeDuringReboot(defaultConfig);
         setAutoLogonAsUser(defaultConfig);
 
         setDriverAutoUpdater(defaultConfig);
@@ -235,6 +236,23 @@ public class FirstTimeRunConfig {
                     askQuestion("Restart after how many tests (0-never restart)", "10");
 
             defaultConfig.setRebootAfterSessions(answer);
+        }
+
+    }
+    
+    private static void setUnregisterNodeDuringReboot(Config defaultConfig) {
+
+        if (!defaultConfig.getAutoStartHub()) { // If this is a HUB, we never want to restart it
+            String
+                    answer =
+                    askQuestion(
+                    		"Would you like to unregister the node during reboot. If answer is no the node will be only marked as down. (1-yes/0-no)", "1");
+
+            if (answer.equals("1")) {
+                defaultConfig.setUnregisterNodeDuringReboot("true");
+            } else {
+            	defaultConfig.setUnregisterNodeDuringReboot("false");
+            }
         }
 
     }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/GridStatus.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/GridStatus.java
@@ -102,6 +102,9 @@ public class GridStatus extends ExecuteOSTask {
             getJsonResponse()
                     .addKeyValues(JsonCodec.WebDriver.Grid.NODE_SESSIONS_LIMIT,
                             RuntimeConfig.getConfig().getRebootAfterSessions());
+            getJsonResponse()
+            .addKeyValues(JsonCodec.WebDriver.Grid.NODE_WILL_UNREGISTER_DURING_REBOOT,
+                    RuntimeConfig.getConfig().getUnregisterNodeDuringReboot());
 
             return getJsonResponse().getJson();
         } catch (Exception error) {

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/GridStatus.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/GridStatus.java
@@ -55,6 +55,7 @@ public class GridStatus extends ExecuteOSTask {
     public static final String HASH_OBJECT_DESCRIBING_THE_NODE_CONFIG_PROCESS = "Hash object describing the NodeConfig Process";
     public static final String LIST_OF_RECORDED_SESSIONS = "List of recorded sessions";
     public static final String INTEGER_UPPER_LIMIT_BEFORE_THE_BOX_REBOOTS = "Integer upper limit before the box reboots";
+    public static final String BOOLEAN_IF_NODE_WILL_UNREGISTER_DURING_REBOOT = "Boolean if node will unregister during reboot.";
 
     public static final String DEPRECATED_STARTED_SESSIONS_KEY = "node_sessions_started";
     public static final String DEPRECATION_WARNING = "[DEPRECATION WARNING] - The " + DEPRECATED_STARTED_SESSIONS_KEY + " key returned from the node's " + TaskDescriptions.Endpoints.GRID_STATUS +"  endpoint indicates that the node is using old version of Selenium Grid Extras, please update it";
@@ -81,6 +82,7 @@ public class GridStatus extends ExecuteOSTask {
         addResponseDescription(JsonCodec.WebDriver.Grid.NODE_INFO, HASH_OBJECT_DESCRIBING_THE_NODE_CONFIG_PROCESS);
         addResponseDescription(JsonCodec.WebDriver.Grid.RECORDED_SESSIONS, LIST_OF_RECORDED_SESSIONS);
         addResponseDescription(JsonCodec.WebDriver.Grid.NODE_SESSIONS_LIMIT, INTEGER_UPPER_LIMIT_BEFORE_THE_BOX_REBOOTS);
+        addResponseDescription(JsonCodec.WebDriver.Grid.NODE_WILL_UNREGISTER_DURING_REBOOT, BOOLEAN_IF_NODE_WILL_UNREGISTER_DURING_REBOOT);
 
     }
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/GridStatus.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/tasks/GridStatus.java
@@ -55,7 +55,7 @@ public class GridStatus extends ExecuteOSTask {
     public static final String HASH_OBJECT_DESCRIBING_THE_NODE_CONFIG_PROCESS = "Hash object describing the NodeConfig Process";
     public static final String LIST_OF_RECORDED_SESSIONS = "List of recorded sessions";
     public static final String INTEGER_UPPER_LIMIT_BEFORE_THE_BOX_REBOOTS = "Integer upper limit before the box reboots";
-    public static final String BOOLEAN_IF_NODE_WILL_UNREGISTER_DURING_REBOOT = "Boolean if node will unregister during reboot.";
+    public static final String BOOLEAN_IF_NODE_WILL_UNREGISTER_DURING_REBOOT = "Boolean if node will unregister during reboot immediately so test clients will get an error if they try to connect. Otherwise the node will be only marked as down and test clients are stored in a queue until node is up again.";
 
     public static final String DEPRECATED_STARTED_SESSIONS_KEY = "node_sessions_started";
     public static final String DEPRECATION_WARNING = "[DEPRECATION WARNING] - The " + DEPRECATED_STARTED_SESSIONS_KEY + " key returned from the node's " + TaskDescriptions.Endpoints.GRID_STATUS +"  endpoint indicates that the node is using old version of Selenium Grid Extras, please update it";

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/json/JsonCodec.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/json/JsonCodec.java
@@ -185,6 +185,7 @@ public class JsonCodec {
             public static final String HUB_INFO = "hub_info";
             public static final String NODE_INFO = "node_info";
             public static final String NODE_SESSIONS_LIMIT = "node_sessions_limit";
+            public static final String NODE_WILL_UNREGISTER_DURING_REBOOT = "node_will_unregister_during_reboot";
             public static final String NODE = "node";
             public static final String PORT = "port";
             public static final String HOST = "host";

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/tasks/GridStatusTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/tasks/GridStatusTest.java
@@ -64,6 +64,7 @@ public class GridStatusTest {
         expectedJsonResponse.put("out", new ArrayList());
         expectedJsonResponse.put("error", new ArrayList());
         expectedJsonResponse.put("node_sessions_limit", new ArrayList());
+        expectedJsonResponse.put("node_will_unregister_during_reboot", new ArrayList());
         expectedJsonResponse.put("node_running", new ArrayList());
         expectedJsonResponse.put("node_info", new ArrayList());
         expectedJsonResponse.put("hub_running", new ArrayList());
@@ -97,6 +98,7 @@ public class GridStatusTest {
         expected.put(JsonCodec.WebDriver.Grid.NODE_INFO, GridStatus.HASH_OBJECT_DESCRIBING_THE_NODE_CONFIG_PROCESS);
         expected.put(JsonCodec.WebDriver.Grid.RECORDED_SESSIONS, GridStatus.LIST_OF_RECORDED_SESSIONS);
         expected.put(JsonCodec.WebDriver.Grid.NODE_SESSIONS_LIMIT, GridStatus.INTEGER_UPPER_LIMIT_BEFORE_THE_BOX_REBOOTS);
+        expected.put(JsonCodec.WebDriver.Grid.NODE_WILL_UNREGISTER_DURING_REBOOT, GridStatus.BOOLEAN_IF_NODE_WILL_UNREGISTER_DURING_REBOOT);
         expected.put(JsonCodec.ERROR, JsonResponseBuilder.ERROR_RECEIVED_DURING_EXECUTION_OF_COMMAND);
         expected.put(JsonCodec.OUT, JsonResponseBuilder.ALL_OF_THE_STANDARD_OUT_RECEIVED_FROM_THE_SYSTEM );
         expected.put(JsonCodec.EXIT_CODE, JsonResponseBuilder.EXIT_CODE_FOR_OPERATION );

--- a/SeleniumGridExtras/src/test/resources/fixtures/configs/additional_classpath.json
+++ b/SeleniumGridExtras/src/test/resources/fixtures/configs/additional_classpath.json
@@ -89,6 +89,7 @@
     "hub_config_files": [],
     "config_puller_http_timeout": 5000,
     "auto_start_hub": "0",
+    "unregisterNodeDuringReboot": "true",
     "chromedriver": {
       "bit": "32",
       "directory": "/tmp/webdriver/chromedriver",


### PR DESCRIPTION
Added configurable parameter to can decide if a node shall be unregistered during reboot or only marked as taken down. For our test cloud system that fires a lot of tests against our selenium grid it is better if we mark the node immediately as down so test runs are put in the queue until the node is back again instead of getting errors.