### PR TITLE
Fix #289 - if it's a hub disable rebooting by default

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -229,7 +229,9 @@ public class FirstTimeRunConfig {
 
     private static void setRebootAfterSessionLimit(Config defaultConfig) {
 
-        if (!defaultConfig.getAutoStartHub()) { // If this is a HUB, we never want to restart it
+        if (defaultConfig.getAutoStartHub()) { // If this is a HUB, we never want to restart it
+        	defaultConfig.setRebootAfterSessions("0");
+        } else {
             String
                     answer =
                     askQuestion("Restart after how many tests (0-never restart)", "10");


### PR DESCRIPTION
This just overrides the default config for the reboot_after_sessions option (setting it to 0) if the auto start hub is set. 