### PR TITLE
Fix #310: Windows user is asked for bitness of ChromeDriver

### DIFF
--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/downloader/GridExtrasDownloaderTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/downloader/GridExtrasDownloaderTest.java
@@ -160,8 +160,8 @@ public class GridExtrasDownloaderTest {
 
     @Test
     public void testGetAllAssets() throws Exception {
-        String expectedVersionOldest = "1.2.3";
-        String expectedVersionFifthOldest = "1.3.3";
+        String expectedVersionOldest = "1.3.0";
+        String expectedVersionFifthOldest = "1.5.0";
         List<Map<String, String>> actual = downloader.getAllDownloadableAssets();
         int actualSize = actual.size();
 
@@ -170,7 +170,7 @@ public class GridExtrasDownloaderTest {
         assertEquals("SeleniumGridExtras-" + expectedVersionOldest +"-SNAPSHOT-jar-with-dependencies.jar",
                 actual.get(actualSize - 1).keySet().toArray()[0]);
 
-        assertEquals("https://github.com/groupon/Selenium-Grid-Extras/releases/download/v" + expectedVersionOldest + "/SeleniumGridExtras-" + expectedVersionOldest + "-SNAPSHOT-jar-with-dependencies.jar",
+        assertEquals("https://github.com/groupon/Selenium-Grid-Extras/releases/download/v." + expectedVersionOldest + "/SeleniumGridExtras-" + expectedVersionOldest + "-SNAPSHOT-jar-with-dependencies.jar",
                 actual.get(actualSize - 1).values().toArray()[0]);
 
 

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/utilities/HttpUtilityTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/utilities/HttpUtilityTest.java
@@ -22,7 +22,7 @@ public class HttpUtilityTest {
 
   @Test
   public void test404Page() throws Exception {
-    assertEquals(404, HttpUtility.getRequest(new URL("http://xkcd.com/404")).getResponseCode());
+    assertEquals(404, HttpUtility.getRequest(new URL("https://xkcd.com/404")).getResponseCode());
   }
 
   @Test
@@ -37,13 +37,13 @@ public class HttpUtilityTest {
 
   @Test
   public void testGetAsString() throws Exception {
-    assertEquals("", HttpUtility.getRequestAsString(new URL("http://xkcd.com/404")));
+    assertEquals("", HttpUtility.getRequestAsString(new URL("https://xkcd.com/404")));
   }
 
     @Test
     public void testCheckIfUrlStatusCode() throws Exception{
         assertEquals(200, HttpUtility.checkIfUrlStatusCode(new URL("http://google.com")));
-        assertEquals(404, HttpUtility.checkIfUrlStatusCode(new URL("http://xkcd.com/404")));
+        assertEquals(404, HttpUtility.checkIfUrlStatusCode(new URL("https://xkcd.com/404")));
         assertEquals(301, HttpUtility.checkIfUrlStatusCode(new URL("http://github.com/groupon/Selenium-Grid-Extras/releases/download/v1.5.0/SeleniumGridExtras-1.5.0-SNAPSHOT-jar-with-dependencies.jar")));
         assertEquals(200, HttpUtility.checkIfUrlStatusCode(new URL("https://github.com/groupon/Selenium-Grid-Extras/releases/download/v1.5.0/SeleniumGridExtras-1.5.0-SNAPSHOT-jar-with-dependencies.jar")));
     }


### PR DESCRIPTION
This addresses #310 - This proposed fix presents the user options based off the information from the [ChromeDriver version manifest](http://chromedriver.storage.googleapis.com/). It will display only the options available (32 or 64 bit) for the user's OS and the target ChromeDriver version.