### PR TITLE
Fix #303: Setup always pulls down 64-bit Geckodriver 

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -298,7 +298,7 @@ public class FirstTimeRunConfig {
         String bitOfChromeDriver = JsonCodec.WebDriver.Downloader.BIT_32;
         String[] bitVersionsChromeDriver = ChromeDriverDownloader.getBitArchitecturesForVersion(versionOfChrome);
         if (bitVersionsChromeDriver.length > 1) {
-            bitOfChromeDriver = askQuestion("What bit of ChromeDriver should we use (" + StringUtils.join(bitVersionsChromeDriver, ", ") + ")?");
+            bitOfChromeDriver = askQuestion("What bit of ChromeDriver should we use (" + StringUtils.join(bitVersionsChromeDriver, ", ") + ")?", JsonCodec.WebDriver.Downloader.BIT_32);
         } else if (bitVersionsChromeDriver.length == 1) {
             bitOfChromeDriver = bitVersionsChromeDriver[0];
         } else {
@@ -318,7 +318,7 @@ public class FirstTimeRunConfig {
         String bitOfGeckoDriver = JsonCodec.WebDriver.Downloader.BIT_32;
         String[] bitVersionsGeckoDriver = GeckoDriverDownloader.getBitArchitecturesForVersion(versionOfGecko);
         if (bitVersionsGeckoDriver.length > 1) {
-            bitOfGeckoDriver = askQuestion("What bit of GeckoDriver should we use (" + StringUtils.join(bitVersionsGeckoDriver, ", ") + ")?");
+            bitOfGeckoDriver = askQuestion("What bit of GeckoDriver should we use (" + StringUtils.join(bitVersionsGeckoDriver, ", ") + ")?", JsonCodec.WebDriver.Downloader.BIT_32);
         } else if (bitVersionsGeckoDriver.length == 1) {
             bitOfGeckoDriver = bitVersionsGeckoDriver[0];
         } else {

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -297,35 +297,28 @@ public class FirstTimeRunConfig {
         String bitOfChromeDriver = JsonCodec.WebDriver.Downloader.BIT_32;
         String[] bitVersionsChromeDriver = ChromeDriverDownloader.getBitArchitecturesForVersion(versionOfChrome);
         if (bitVersionsChromeDriver.length > 1) {
-            bitOfChromeDriver = askQuestion("What bit of ChromeDriver should we use (" + StringUtils.join(bitVersionsChromeDriver, ",") + ")?");
+            bitOfChromeDriver = askQuestion("What bit of ChromeDriver should we use (" + StringUtils.join(bitVersionsChromeDriver, ", ") + ")?");
         } else if (bitVersionsChromeDriver.length == 1) {
             bitOfChromeDriver = bitVersionsChromeDriver[0];
         } else {
-            System.out.println("WARNING: We were unable to find the correct bit of ChromeDriver for this OS and ChromeDriver version: " + versionOfChrome + "  so will default to '32' please update this to be more accurate, or grid may not function properly");
+            System.out.println("\nWARNING: We were unable to find the correct bit of ChromeDriver for this OS and ChromeDriver version: " + versionOfChrome + "  so will default to '32' please update this to be more accurate, or grid may not function properly\n");
         }
         defaultConfig.getChromeDriver().setBit(bitOfChromeDriver);
 
         if (RuntimeConfig.getOS().isWindows()) {
             String bitOfIEDriver = RuntimeConfig.getOS().getWindowsRealArchitecture();
             bitOfIEDriver =
-                    askQuestion("What bit of IE Driver should we use (32 or 64)?", bitOfIEDriver);
+                    askQuestion("What bit of IE Driver should we use (32, 64)?", bitOfIEDriver);
             bitOfIEDriver = bitOfIEDriver.equals("64") ? "x64" : "Win32";
             defaultConfig.getIEdriver().setVersion(versionOfIEDriver);
             defaultConfig.getIEdriver().setBit(bitOfIEDriver);
         }
 
-        System.out.println(
-                "Current Selenium Driver Version: " + defaultConfig.getWebdriver().getVersion());
-        System.out
-                .println("Current IE Driver Version: " + defaultConfig.getIEdriver().getVersion());
-        System.out.println(
-                "Current Chrome Driver Version: " + defaultConfig.getChromeDriver().getVersion());
-        System.out
-                .println("Current Chrome Driver Bit: " + defaultConfig.getChromeDriver().getBit());
-        System.out.println("Current IE Driver Bit: " + defaultConfig.getIEdriver().getBit());
-        System.out.println("Current Gecko Driver Version: "
-                + defaultConfig.getGeckoDriver().getVersion());
 
+        System.out.println("Current Selenium Driver Version: " + defaultConfig.getWebdriver().getVersion());
+        System.out.printf("Current Chrome Driver Version: %s (%s bit)\n", defaultConfig.getChromeDriver().getVersion(), defaultConfig.getChromeDriver().getBit());
+        System.out.printf("Current IE Driver Version: %s (%s bit)\n", defaultConfig.getIEdriver().getVersion(), defaultConfig.getIEdriver().getBit());
+        System.out.printf("Current Gecko Driver Version: %s (%s bit)\n", defaultConfig.getGeckoDriver().getVersion(), defaultConfig.getGeckoDriver().getBit());
     }
     
     private static void configureNodes(List<Capability> capabilities, String hubHost,

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -291,12 +291,12 @@ public class FirstTimeRunConfig {
                     askQuestion("What version of Chrome Driver should we use?", versionOfChrome);
         }
 
-        String bitOfChrome = JsonCodec.WebDriver.Downloader.BIT_32;
-        String[] bitVersions = ChromeDriverDownloader.getBitArchitecturesForVersion(versionOfChrome);
-        if (bitVersions.length > 1) {
-            bitOfChrome = askQuestion("What bit of ChromeDriver should we use (" + StringUtils.join(bitVersions, ",") + ")?");
-        } else if (bitVersions.length == 1) {
-            bitOfChrome = bitVersions[0];
+        String bitOfChromeDriver = JsonCodec.WebDriver.Downloader.BIT_32;
+        String[] bitVersionsChromeDriver = ChromeDriverDownloader.getBitArchitecturesForVersion(versionOfChrome);
+        if (bitVersionsChromeDriver.length > 1) {
+            bitOfChromeDriver = askQuestion("What bit of ChromeDriver should we use (" + StringUtils.join(bitVersionsChromeDriver, ",") + ")?");
+        } else if (bitVersionsChromeDriver.length == 1) {
+            bitOfChromeDriver = bitVersionsChromeDriver[0];
         } else {
             System.out.println("WARNING: We were unable to find the correct bit of ChromeDriver for this OS and ChromeDriver version: " + versionOfChrome + "  so will default to '32' please update this to be more accurate, or grid may not function properly");
         }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -45,6 +45,7 @@ import com.groupon.seleniumgridextras.browser.BrowserVersionDetector;
 import com.groupon.seleniumgridextras.config.capabilities.Capability;
 import com.groupon.seleniumgridextras.config.remote.ConfigPusher;
 import com.groupon.seleniumgridextras.downloader.ChromeDriverDownloader;
+import com.groupon.seleniumgridextras.downloader.GeckoDriverDownloader;
 import com.groupon.seleniumgridextras.downloader.webdriverreleasemanager.WebDriverReleaseManager;
 import com.groupon.seleniumgridextras.os.GridPlatform;
 import com.groupon.seleniumgridextras.tasks.SetAutoLogonUser;
@@ -314,6 +315,16 @@ public class FirstTimeRunConfig {
             defaultConfig.getIEdriver().setBit(bitOfIEDriver);
         }
 
+        String bitOfGeckoDriver = JsonCodec.WebDriver.Downloader.BIT_32;
+        String[] bitVersionsGeckoDriver = GeckoDriverDownloader.getBitArchitecturesForVersion(versionOfGecko);
+        if (bitVersionsGeckoDriver.length > 1) {
+            bitOfGeckoDriver = askQuestion("What bit of GeckoDriver should we use (" + StringUtils.join(bitVersionsGeckoDriver, ", ") + ")?");
+        } else if (bitVersionsGeckoDriver.length == 1) {
+            bitOfGeckoDriver = bitVersionsGeckoDriver[0];
+        } else {
+            System.out.println("\nWARNING: We were unable to find the correct bit of GeckoDriver for this OS and GeckoDriver version: " + versionOfGecko + "  so will default to '32' please update this to be more accurate, or grid may not function properly\n");
+        }
+        defaultConfig.getGeckoDriver().setBit(bitOfGeckoDriver);
 
         System.out.println("Current Selenium Driver Version: " + defaultConfig.getWebdriver().getVersion());
         System.out.printf("Current Chrome Driver Version: %s (%s bit)\n", defaultConfig.getChromeDriver().getVersion(), defaultConfig.getChromeDriver().getBit());

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -290,6 +290,9 @@ public class FirstTimeRunConfig {
             versionOfChrome =
                     askQuestion("What version of Chrome Driver should we use?", versionOfChrome);
         }
+        defaultConfig.getChromeDriver().setVersion(versionOfChrome);
+        defaultConfig.getGeckoDriver().setVersion(versionOfGecko);
+        defaultConfig.getWebdriver().setVersion(versionOfWebDriver);
 
         String bitOfChromeDriver = JsonCodec.WebDriver.Downloader.BIT_32;
         String[] bitVersionsChromeDriver = ChromeDriverDownloader.getBitArchitecturesForVersion(versionOfChrome);
@@ -300,8 +303,8 @@ public class FirstTimeRunConfig {
         } else {
             System.out.println("WARNING: We were unable to find the correct bit of ChromeDriver for this OS and ChromeDriver version: " + versionOfChrome + "  so will default to '32' please update this to be more accurate, or grid may not function properly");
         }
+        defaultConfig.getChromeDriver().setBit(bitOfChromeDriver);
 
-        defaultConfig.getWebdriver().setVersion(versionOfWebDriver);
         if (RuntimeConfig.getOS().isWindows()) {
             String bitOfIEDriver = RuntimeConfig.getOS().getWindowsRealArchitecture();
             bitOfIEDriver =
@@ -310,10 +313,6 @@ public class FirstTimeRunConfig {
             defaultConfig.getIEdriver().setVersion(versionOfIEDriver);
             defaultConfig.getIEdriver().setBit(bitOfIEDriver);
         }
-        defaultConfig.getChromeDriver().setVersion(versionOfChrome);
-        defaultConfig.getChromeDriver().setBit(bitOfChrome);
-
-        defaultConfig.getGeckoDriver().setVersion(versionOfGecko);
 
         System.out.println(
                 "Current Selenium Driver Version: " + defaultConfig.getWebdriver().getVersion());

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/FirstTimeRunConfig.java
@@ -317,8 +317,11 @@ public class FirstTimeRunConfig {
 
         System.out.println("Current Selenium Driver Version: " + defaultConfig.getWebdriver().getVersion());
         System.out.printf("Current Chrome Driver Version: %s (%s bit)\n", defaultConfig.getChromeDriver().getVersion(), defaultConfig.getChromeDriver().getBit());
-        System.out.printf("Current IE Driver Version: %s (%s bit)\n", defaultConfig.getIEdriver().getVersion(), defaultConfig.getIEdriver().getBit());
         System.out.printf("Current Gecko Driver Version: %s (%s bit)\n", defaultConfig.getGeckoDriver().getVersion(), defaultConfig.getGeckoDriver().getBit());
+        if (defaultConfig.getIEdriver() != null && defaultConfig.getIEdriver().getVersion() != null)
+        {
+            System.out.printf("Current IE Driver Version: %s (%s bit)\n", defaultConfig.getIEdriver().getVersion(), defaultConfig.getIEdriver().getBit());
+        }
     }
     
     private static void configureNodes(List<Capability> capabilities, String hubHost,

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/downloader/GeckoDriverDownloaderTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/downloader/GeckoDriverDownloaderTest.java
@@ -30,7 +30,7 @@ public class GeckoDriverDownloaderTest {
 
     testDir.mkdir();
 
-    downloader = new GeckoDriverDownloader(VERSION);
+    downloader = new GeckoDriverDownloader(VERSION, "32");
     downloader.setDestinationDir(testDir.getAbsolutePath());
   }
 
@@ -74,8 +74,8 @@ public class GeckoDriverDownloaderTest {
   @Test
   public void testGetOSNames() throws Exception {
     assertEquals("macos", downloader.getMacName());
-    assertEquals("win64", downloader.getWindowsName());
-    assertEquals("linux64", downloader.getLinuxName());
+    assertEquals("win", downloader.getWindowsName());
+    assertEquals("linux", downloader.getLinuxName());
   }
   
   @Test

--- a/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/utilities/HttpUtilityTest.java
+++ b/SeleniumGridExtras/src/test/java/com/groupon/seleniumgridextras/utilities/HttpUtilityTest.java
@@ -8,6 +8,7 @@ import java.net.URL;
 import java.net.UnknownHostException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class HttpUtilityTest {
 
@@ -30,9 +31,21 @@ public class HttpUtilityTest {
     assertEquals(200, HttpUtility.getRequest(new URL("http://google.com")).getResponseCode());
   }
 
-  @Test(expected = UnknownHostException.class)
+  @Test
   public void testUnknownHost() throws Exception {
-    HttpUtility.getRequest(new URL("http://googasdfasfdkjashfdkjahsfdle.com/")).getResponseCode();
+    boolean expectedExceptionThrown = false;
+    try {
+      HttpUtility.getRequest(new URL("http://googasdfasfdkjashfdkjahsfdle.com/")).getResponseCode();
+    }
+    catch (UnknownHostException uhe)
+    {
+      expectedExceptionThrown = true;
+    }
+    catch (ConnectException ce)
+    {
+        expectedExceptionThrown = true;
+    }
+    assertTrue("Expected either UnknownHostException or ConnectException", expectedExceptionThrown);
   }
 
   @Test


### PR DESCRIPTION
These changes are similar to the fix for [#310 Windows user is asked for bitness of ChromeDriver].
It will check the bit architectures available for a given GeckoDriver version and the current OS and present the user with options (32 | 64) if available, and will default to downloading the 32 bit version of GeckoDriver. Previously, `GeckoDriverDownloader` was hardcoded to get only 64 bit versions of Windows and Linux.

Also included is a fix for a unit test: `testUnknownHost`. Depending on DNS settings of the network running the test, it was possible in some configurations that unresolved hosts are handled by a type of lookup service/search to suggest domains, therefore resulting in a `ConnectException` instead of `UnknownHostException`
