### PR TITLE
Fixing the proxy tag removal when selenium 3.0 used

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridNode.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridNode.java
@@ -40,6 +40,7 @@ public class GridNode {
   private Integer registerCycle;
   private Integer nodeStatusCheckTimeout;
   private String appiumStartCommand;
+  private String proxy;
 
   //Only test the node status 1 time, since the limit checker is
   //Since DefaultRemoteProxy.java does this check failedPollingTries >= downPollingLimit
@@ -186,6 +187,7 @@ public class GridNode {
         node.getConfiguration().setAppiumStartCommand(topLevelJson.get("appiumStartCommand") != null
                 ? topLevelJson.get("appiumStartCommand").getAsString() : null);
         node.setLoadedFromFile(filename);
+        node.getConfiguration().setProxy(topLevelJson.get("proxy") != null ? topLevelJson.get("proxy").getAsString() : null );
         node.writeToFile(filename);
         
         return node;


### PR DESCRIPTION
Defect:
https://github.com/groupon/Selenium-Grid-Extras/issues/286 
Summary : 
When selenium 3.0 used proxy tag in config get removed automatically. Because of it we cannot use selenium grid extensions. @smccarthy  pls review the changes and merge it.
Thanks
Shankar
