### PR TITLE
Fixing selenium 3.7.1 incompatibility issues

### DIFF
--- a/SeleniumGridExtras/pom.xml
+++ b/SeleniumGridExtras/pom.xml
@@ -71,11 +71,6 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.5</version>
         </dependency>
-        <dependency> <!--  Selenium 3.7.1 comes with byte-buddy 1.7.5 -->
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
-            <version>1.7.5</version>
-        </dependency>
         <dependency> <!--  Selenium 3.7.1 comes with gson 2.8.2 -->
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
@@ -125,7 +120,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.5</version>
+            <version>2.12.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/SeleniumGridExtras/pom.xml
+++ b/SeleniumGridExtras/pom.xml
@@ -19,11 +19,11 @@
     </repositories>
 
     <properties>
-        <version.selenium>3.5.3</version.selenium>
+        <version.selenium>3.7.1</version.selenium>
     </properties>
 
     <dependencies>
-        <dependency> <!-- Selenium 2.53.1 comes with jna-platform 4.1.0 -->
+        <dependency> <!-- Selenium 3.7.1 comes with jna-platform 4.1.0 -->
             <groupId>net.java.dev.jna</groupId> <!-- Needed for BrowerVersionDetector (for IE) -->
             <artifactId>jna-platform</artifactId>
             <version>4.1.0</version>
@@ -50,31 +50,36 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
-         <dependency> <!--  Selenium 2.53.1 comes with commons-io 2.4 -->
+         <dependency> <!--  Selenium 3.7.1 comes with commons-io 2.5 -->
             <groupId>commons-io</groupId> <!-- GridHub.writeToFile requires this -->
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.5</version>
         </dependency>
-         <dependency> <!--  Selenium 2.53.1 comes with commons-codec 1.10 -->
+         <dependency> <!--  Selenium 3.7.1 comes with commons-codec 1.10 -->
             <groupId>commons-codec</groupId> <!-- ScreenshotUtility.encodeStreamToBase64 requires this -->
             <artifactId>commons-codec</artifactId>
             <version>1.10</version>
         </dependency>
         <!-- Needed for `Should we store all of these configs in central location on the HUB node and update from there? (1-yes/0-no)` -->
-         <dependency> <!--  Selenium 2.53.1 comes with httpclient 4.5.1 -->
+         <dependency> <!--  Selenium 3.7.1 comes with httpclient 4.5.3 -->
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.1</version>
+            <version>4.5.3</version>
         </dependency>
-        <dependency> <!-- Selenium 2.53.1 comes with commons-lang3 3.4 -->
+        <dependency> <!-- Selenium 3.7.1 comes with commons-lang3 3.5 -->
             <groupId>org.apache.commons</groupId> <!-- Needed all over -->
             <artifactId>commons-lang3</artifactId>
-            <version>3.3.2</version>
+            <version>3.5</version>
         </dependency>
-        <dependency>
+        <dependency> <!--  Selenium 3.7.1 comes with byte-buddy 1.7.5 -->
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.7.5</version>
+        </dependency>
+        <dependency> <!--  Selenium 3.7.1 comes with gson 2.8.2 -->
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.1</version>
+            <version>2.8.2</version>
         </dependency>
         <dependency>
             <groupId>net.coobird</groupId>
@@ -106,7 +111,7 @@
             <artifactId>xuggler</artifactId>
             <version>0.16</version>
         </dependency>
-        <dependency> <!-- selenium-api-2.53.1 comes with guava 19.0 -->
+        <dependency> <!-- selenium-api-3.7.1 comes with guava 23.0 -->
             <artifactId>guava</artifactId> <!-- Needed for UpgradeGridExtrasTask.getSanitizedReleaseList -->
             <groupId>com.google.guava</groupId>
             <type>jar</type>
@@ -120,7 +125,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.0.31-beta</version>
+            <version>1.9.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/AutoProxy.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/AutoProxy.java
@@ -3,7 +3,7 @@ package com.groupon.seleniumgridextras.grid.proxies;
 
 import org.openqa.grid.common.RegistrationRequest;
 import org.openqa.grid.common.exception.RemoteUnregisterException;
-import org.openqa.grid.internal.Registry;
+import org.openqa.grid.internal.GridRegistry;
 import org.openqa.grid.internal.TestSession;
 import org.openqa.grid.internal.listeners.SelfHealingProxy;
 import org.openqa.grid.internal.utils.HtmlRenderer;
@@ -24,7 +24,7 @@ public class AutoProxy extends DefaultRemoteProxy implements SelfHealingProxy {
   private Date startTime;
   private HtmlRenderer renderer = new ExtrasHtmlRenderer(this);
 
-  public AutoProxy(RegistrationRequest request, Registry registry) {
+  public AutoProxy(RegistrationRequest request, GridRegistry registry) {
     super(request, registry);
     NodeManager nodeManager = new NodeManager(this);
     new Thread(nodeManager).start();

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
@@ -52,7 +52,7 @@ import com.groupon.seleniumgridextras.utilities.threads.video.RemoteVideoRecordi
 import com.groupon.seleniumgridextras.utilities.threads.video.VideoDownloaderCallable;
 import org.apache.log4j.Logger;
 import org.openqa.grid.common.RegistrationRequest;
-import org.openqa.grid.internal.Registry;
+import org.openqa.grid.internal.GridRegistry;
 import org.openqa.grid.internal.TestSession;
 import org.openqa.grid.internal.listeners.TestSessionListener;
 import org.openqa.grid.selenium.proxy.DefaultRemoteProxy;
@@ -77,8 +77,7 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
 
     private static Logger logger = Logger.getLogger(SetupTeardownProxy.class);
 
-
-    public SetupTeardownProxy(RegistrationRequest request, Registry registry) {
+    public SetupTeardownProxy(RegistrationRequest request, GridRegistry registry) {
         super(request, registry);
         logger.info(String.format("Attaching node %s", this.getId()));
     }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/servlets/ProxyStatusJsonServlet.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/servlets/ProxyStatusJsonServlet.java
@@ -3,7 +3,7 @@ package com.groupon.seleniumgridextras.grid.servlets;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import org.openqa.grid.internal.ProxySet;
-import org.openqa.grid.internal.Registry;
+import org.openqa.grid.internal.GridRegistry;
 import org.openqa.grid.internal.RemoteProxy;
 import org.openqa.grid.internal.TestSlot;
 import org.openqa.grid.web.servlet.RegistryBasedServlet;
@@ -27,7 +27,7 @@ public class ProxyStatusJsonServlet extends RegistryBasedServlet {
         this(null);
     }
 
-    public ProxyStatusJsonServlet(Registry registry) {
+    public ProxyStatusJsonServlet(GridRegistry registry) {
         super(registry);
     }
 


### PR DESCRIPTION
These changes are necessary for grid extras to work with selenium 3.7.1. Please refer to the commit messages.

For the Registry to GridRegistry change, refer to https://github.com/SeleniumHQ/selenium/commit/6a198866d74