### PR TITLE
Customizable grid-extras-port in nodes

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridNode.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/config/GridNode.java
@@ -65,6 +65,8 @@ public class GridNode {
       registerCycle = 5000;
       nodeStatusCheckTimeout = 10000;
       downPollingLimit = 0;
+      // Init custom with grid_extras_port value from node
+      custom.put(Config.GRID_EXTRAS_PORT, RuntimeConfig.getGridExtrasPort());
     }
   }
 
@@ -131,6 +133,11 @@ public class GridNode {
         if(topLevelJson.get("custom") != null) {
           Map<String, Object> customMap = new Gson().fromJson(topLevelJson.get("custom"), type);
           doubleToIntConverter(customMap);
+          // Init custom with grid_extras_port value from node if it doesn't exist
+          if (!customMap.containsKey(Config.GRID_EXTRAS_PORT))
+          {
+              customMap.put(Config.GRID_EXTRAS_PORT, RuntimeConfig.getGridExtrasPort());
+          }
           node.setCustom(customMap);
         }
         

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
@@ -106,13 +106,14 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
         try {
 
             String host = session.getSlot().getRemoteURL().getHost();
+            int port = Integer.parseInt(session.getSlot().getRemoteURL().getHost());
 
             logNewSessionHistoryAsync(session);
 
             CommonThreadPool.startCallable(
                     new RemoteGridExtrasAsyncCallable(
                             host,
-                            RuntimeConfig.getGridExtrasPort(),
+                            port,
                             TaskDescriptions.Endpoints.SETUP,
                             new HashMap<String, String>()));
 
@@ -142,6 +143,7 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
 
         Map<String, Object> cap = session.getRequestedCapabilities();
         String browser = (String) cap.get(CapabilityType.BROWSER_NAME);
+        int port = Integer.parseInt(session.getSlot().getRemoteURL().getHost());
 
         if (browser != null &&
                 (browser.equals(BrowserType.IE) ||
@@ -151,7 +153,7 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
             CommonThreadPool.startCallable(
                     new RemoteGridExtrasAsyncCallable(
                             this.getRemoteHost().getHost(),
-                            RuntimeConfig.getGridExtrasPort(),
+                            port,
                             TaskDescriptions.Endpoints.KILL_IE,
                             new HashMap<String, String>()));
         }
@@ -169,7 +171,8 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
                 CommonThreadPool.startCallable(
                         new VideoDownloaderCallable(
                                 session.getExternalKey().getKey(),
-                                session.getSlot().getRemoteURL().getHost()));
+                                session.getSlot().getRemoteURL().getHost(),
+                                session.getSlot().getProxy().getConfig().custom.get("grid-extras-port")));
             }
         }
 
@@ -181,7 +184,7 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
                         new HashMap<String, String>()));
 
 
-        if (NodeRestartCallable.timeToReboot(this.getRemoteHost().getHost(), this.getId())) {
+        if (NodeRestartCallable.timeToReboot(this.getRemoteHost().getHost(), this.getId(),session)) {
             this.setAvailable(false);
             this.setRestarting(true);
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/SetupTeardownProxy.java
@@ -39,6 +39,7 @@
 package com.groupon.seleniumgridextras.grid.proxies;
 
 import com.google.common.base.Throwables;
+import com.groupon.seleniumgridextras.config.Config;
 import com.groupon.seleniumgridextras.config.RuntimeConfig;
 import com.groupon.seleniumgridextras.config.capabilities.BrowserType;
 import com.groupon.seleniumgridextras.grid.proxies.sessions.threads.NodeRestartCallable;
@@ -83,7 +84,6 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
         logger.info(String.format("Attaching node %s", this.getId()));
     }
 
-
     @Override
     public TestSession getNewSession(Map<String, Object> requestedCapability) {
         if (isDown() || isRestarting()) {
@@ -106,8 +106,8 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
         try {
 
             String host = session.getSlot().getRemoteURL().getHost();
-            int port = Integer.parseInt(session.getSlot().getRemoteURL().getHost());
-
+            int port = getNodeExtrasPort(session);
+         
             logNewSessionHistoryAsync(session);
 
             CommonThreadPool.startCallable(
@@ -143,7 +143,7 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
 
         Map<String, Object> cap = session.getRequestedCapabilities();
         String browser = (String) cap.get(CapabilityType.BROWSER_NAME);
-        int port = Integer.parseInt(session.getSlot().getRemoteURL().getHost());
+        int port = getNodeExtrasPort(session);
 
         if (browser != null &&
                 (browser.equals(BrowserType.IE) ||
@@ -172,19 +172,19 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
                         new VideoDownloaderCallable(
                                 session.getExternalKey().getKey(),
                                 session.getSlot().getRemoteURL().getHost(),
-                                session.getSlot().getProxy().getConfig().custom.get("grid-extras-port")));
+                                getNodeExtrasPort(session)));
             }
         }
 
         CommonThreadPool.startCallable(
                 new RemoteGridExtrasAsyncCallable(
                         this.getRemoteHost().getHost(),
-                        RuntimeConfig.getGridExtrasPort(),
+                        getNodeExtrasPort(session),
                         TaskDescriptions.Endpoints.TEARDOWN,
                         new HashMap<String, String>()));
 
 
-        if (NodeRestartCallable.timeToReboot(this.getRemoteHost().getHost(), this.getId(),session)) {
+        if (NodeRestartCallable.timeToReboot(this.getRemoteHost().getHost(), this.getId(), session)) {
             this.setAvailable(false);
             this.setRestarting(true);
 
@@ -303,6 +303,20 @@ public class SetupTeardownProxy extends DefaultRemoteProxy implements TestSessio
             return CommonThreadPool.startCallable(new SessionHistoryCallable(session));
         }
         return null;
+    }
+    
+    public static int getNodeExtrasPort(TestSession session){
+        try {
+            
+            String port = session.getSlot().getProxy().getConfig().custom.get(Config.GRID_EXTRAS_PORT);
+            if(port!= null || ! port.equals("")) {
+                return Integer.parseInt(port);
+            }
+        }catch(NumberFormatException e)
+        {
+            logger.info("Error parsing port, returning default");
+        }
+        return RuntimeConfig.getGridExtrasPort();
     }
 
 }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/sessions/threads/NodeRestartCallable.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/sessions/threads/NodeRestartCallable.java
@@ -52,7 +52,7 @@ public class NodeRestartCallable implements Callable {
         }
 
         stopGridNode();
-        NodeRestartCallable.rebootGridExtrasNode(proxy.getRemoteHost().getHost());
+        NodeRestartCallable.rebootGridExtrasNode(proxy.getRemoteHost().getHost(), session);
 
         logger.info(String.format("Proxy restart command sent for %s", proxy.getId()));
         return "Done";
@@ -78,12 +78,13 @@ public class NodeRestartCallable implements Callable {
     }
 
 
-    public static void rebootGridExtrasNode(String host) {
+    public static void rebootGridExtrasNode(String host, TestSession session) {
         logger.info("Asking SeleniumGridExtras to reboot node" + host);
+        int port = Integer.parseInt(session.getSlot().getRemoteURL().getHost());
         Future<String> f = CommonThreadPool.startCallable(
                 new RemoteGridExtrasAsyncCallable(
                         host,
-                        RuntimeConfig.getGridExtrasPort(),
+                        port,
                         TaskDescriptions.Endpoints.REBOOT,
                         new HashMap<String, String>()));
         try {
@@ -97,6 +98,9 @@ public class NodeRestartCallable implements Callable {
     public void stopGridNode() {
 
         logger.info(String.format("Asking proxy %s to stop gracefully", proxy.getId()));
+        
+        int port = Integer.parseInt(session.getSlot().getRemoteURL().getHost());
+
 
         Map<String, String> params = new HashMap<String, String>();
         params.put(JsonCodec.WebDriver.Grid.PORT, String.valueOf(proxy.getRemoteHost().getPort()));
@@ -104,7 +108,7 @@ public class NodeRestartCallable implements Callable {
         Future<String> f = CommonThreadPool.startCallable(
                 new RemoteGridExtrasAsyncCallable(
                         proxy.getRemoteHost().getHost(),
-                        RuntimeConfig.getGridExtrasPort(),
+                        port,
                         TaskDescriptions.Endpoints.STOP_GRID,
                         params));
 
@@ -118,11 +122,13 @@ public class NodeRestartCallable implements Callable {
 
     public void unregister() {
     	boolean unregisterDuringReboot = true;
+        int port = Integer.parseInt(session.getSlot().getRemoteURL().getHost());
+
     	
         Future<String> f = CommonThreadPool.startCallable(
                 new RemoteGridExtrasAsyncCallable(
                 		proxy.getRemoteHost().getHost(),
-                        RuntimeConfig.getGridExtrasPort(),
+                        port,
                         TaskDescriptions.Endpoints.GRID_STATUS,
                         new HashMap<String, String>()));
 
@@ -154,11 +160,12 @@ public class NodeRestartCallable implements Callable {
         }
     }
 
-    public static boolean timeToReboot(String nodeHost, String proxyId) {
+    public static boolean timeToReboot(String nodeHost, String proxyId, TestSession session) {
+        int port = Integer.parseInt(session.getSlot().getRemoteURL().getHost());
         Future<String> f = CommonThreadPool.startCallable(
                 new RemoteGridExtrasAsyncCallable(
                         nodeHost,
-                        RuntimeConfig.getGridExtrasPort(),
+                        port,
                         TaskDescriptions.Endpoints.GRID_STATUS,
                         new HashMap<String, String>()));
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/sessions/threads/NodeRestartCallable.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/proxies/sessions/threads/NodeRestartCallable.java
@@ -80,7 +80,7 @@ public class NodeRestartCallable implements Callable {
 
     public static void rebootGridExtrasNode(String host, TestSession session) {
         logger.info("Asking SeleniumGridExtras to reboot node" + host);
-        int port = Integer.parseInt(session.getSlot().getRemoteURL().getHost());
+        int port = SetupTeardownProxy.getNodeExtrasPort(session);
         Future<String> f = CommonThreadPool.startCallable(
                 new RemoteGridExtrasAsyncCallable(
                         host,
@@ -99,8 +99,7 @@ public class NodeRestartCallable implements Callable {
 
         logger.info(String.format("Asking proxy %s to stop gracefully", proxy.getId()));
         
-        int port = Integer.parseInt(session.getSlot().getRemoteURL().getHost());
-
+        int port = SetupTeardownProxy.getNodeExtrasPort(session);
 
         Map<String, String> params = new HashMap<String, String>();
         params.put(JsonCodec.WebDriver.Grid.PORT, String.valueOf(proxy.getRemoteHost().getPort()));
@@ -122,9 +121,8 @@ public class NodeRestartCallable implements Callable {
 
     public void unregister() {
     	boolean unregisterDuringReboot = true;
-        int port = Integer.parseInt(session.getSlot().getRemoteURL().getHost());
-
-    	
+        int port = SetupTeardownProxy.getNodeExtrasPort(session);
+        
         Future<String> f = CommonThreadPool.startCallable(
                 new RemoteGridExtrasAsyncCallable(
                 		proxy.getRemoteHost().getHost(),
@@ -161,7 +159,7 @@ public class NodeRestartCallable implements Callable {
     }
 
     public static boolean timeToReboot(String nodeHost, String proxyId, TestSession session) {
-        int port = Integer.parseInt(session.getSlot().getRemoteURL().getHost());
+        int port = SetupTeardownProxy.getNodeExtrasPort(session);
         Future<String> f = CommonThreadPool.startCallable(
                 new RemoteGridExtrasAsyncCallable(
                         nodeHost,

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/SessionHistoryCallable.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/SessionHistoryCallable.java
@@ -3,6 +3,7 @@ package com.groupon.seleniumgridextras.utilities.threads;
 import com.google.common.base.Throwables;
 import com.groupon.seleniumgridextras.config.DefaultConfig;
 import com.groupon.seleniumgridextras.config.RuntimeConfig;
+import com.groupon.seleniumgridextras.grid.proxies.SetupTeardownProxy;
 import com.groupon.seleniumgridextras.loggers.SessionHistoryLog;
 import com.groupon.seleniumgridextras.tasks.config.TaskDescriptions;
 import com.groupon.seleniumgridextras.utilities.HttpUtility;
@@ -48,7 +49,7 @@ public class SessionHistoryCallable implements Callable<String> {
 
     protected String notifyNodeGridExtrasOfNewSession() {
         try {
-            int port = Integer.parseInt(session.getSlot().getRemoteURL().getHost());
+            int port = SetupTeardownProxy.getNodeExtrasPort(session);
             URIBuilder uri = new URIBuilder();
             uri.setScheme("http");
             uri.setHost(getSession().getSlot().getRemoteURL().getHost());
@@ -81,7 +82,7 @@ public class SessionHistoryCallable implements Callable<String> {
             sessionDetails.put(JsonCodec.WebDriver.Grid.INTERNAL_KEY, getSession().getInternalKey());
             sessionDetails.put(JsonCodec.WebDriver.Grid.EXTERNAL_KEY, JsonCodec.WebDriver.Grid.NOT_YET_ASSIGNED);
             sessionDetails.put(JsonCodec.WebDriver.Grid.HOST, getSession().getSlot().getRemoteURL().getHost());
-            sessionDetails.put(JsonCodec.WebDriver.Grid.PORT, String.valueOf(getSession().getSlot().getRemoteURL().getPort()));
+            sessionDetails.put(JsonCodec.WebDriver.Grid.PORT, SetupTeardownProxy.getNodeExtrasPort(session));
             sessionDetails.put(JsonCodec.TIMESTAMP, TimeStampUtility.getTimestampAsString());
 //            sessionDetails.put(JsonCodec.WebDriver.Grid.REQUESTED_CAPABILITIES, getSession().getRequestedCapabilities());
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/SessionHistoryCallable.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/SessionHistoryCallable.java
@@ -48,10 +48,11 @@ public class SessionHistoryCallable implements Callable<String> {
 
     protected String notifyNodeGridExtrasOfNewSession() {
         try {
+            int port = Integer.parseInt(session.getSlot().getRemoteURL().getHost());
             URIBuilder uri = new URIBuilder();
             uri.setScheme("http");
             uri.setHost(getSession().getSlot().getRemoteURL().getHost());
-            uri.setPort(RuntimeConfig.getGridExtrasPort());
+            uri.setPort(port);
             uri.setPath(TaskDescriptions.Endpoints.GRID_STATUS);
             if (getSession().getExternalKey() != null) {
                 uri.addParameter(JsonCodec.WebDriver.Grid.NEW_SESSION_PARAM, getSession().getExternalKey().getKey());

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/RemoteVideoRecordingControlCallable.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/RemoteVideoRecordingControlCallable.java
@@ -111,7 +111,7 @@ public class RemoteVideoRecordingControlCallable implements Callable {
     protected String updateLastAction() {
         String m = RemoteVideoRecorderHelper.updateLastAction(
                 this.session.getSlot().getRemoteURL().getHost(),
-                this.session.getSlot().getProxy().getConfig().custom.get("grid-extras-port"),
+                SetupTeardownProxy.getNodeExtrasPort(session),
                 this.session.getExternalKey().getKey(),
                 this.lastAction);
 
@@ -122,7 +122,7 @@ public class RemoteVideoRecordingControlCallable implements Callable {
     protected String stopVideo() {
         String m = RemoteVideoRecorderHelper.stopVideoRecording(
                 this.session.getSlot().getRemoteURL().getHost(),
-                this.session.getSlot().getProxy().getConfig().custom.get("grid-extras-port"),
+                SetupTeardownProxy.getNodeExtrasPort(session),
                 this.session.getExternalKey().getKey());
 
         logger.debug(m);
@@ -133,7 +133,7 @@ public class RemoteVideoRecordingControlCallable implements Callable {
     protected String startVideo() {
         return RemoteVideoRecorderHelper.startVideoRecording(
                 this.session.getSlot().getRemoteURL().getHost(),
-                this.session.getSlot().getProxy().getConfig().custom.get("grid-extras-port"),
+                SetupTeardownProxy.getNodeExtrasPort(session),
                 this.session.getExternalKey().getKey());
     }
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/RemoteVideoRecordingControlCallable.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/RemoteVideoRecordingControlCallable.java
@@ -111,6 +111,7 @@ public class RemoteVideoRecordingControlCallable implements Callable {
     protected String updateLastAction() {
         String m = RemoteVideoRecorderHelper.updateLastAction(
                 this.session.getSlot().getRemoteURL().getHost(),
+                this.session.getSlot().getProxy().getConfig().custom.get("grid-extras-port"),
                 this.session.getExternalKey().getKey(),
                 this.lastAction);
 
@@ -121,6 +122,7 @@ public class RemoteVideoRecordingControlCallable implements Callable {
     protected String stopVideo() {
         String m = RemoteVideoRecorderHelper.stopVideoRecording(
                 this.session.getSlot().getRemoteURL().getHost(),
+                this.session.getSlot().getProxy().getConfig().custom.get("grid-extras-port"),
                 this.session.getExternalKey().getKey());
 
         logger.debug(m);
@@ -131,6 +133,7 @@ public class RemoteVideoRecordingControlCallable implements Callable {
     protected String startVideo() {
         return RemoteVideoRecorderHelper.startVideoRecording(
                 this.session.getSlot().getRemoteURL().getHost(),
+                this.session.getSlot().getProxy().getConfig().custom.get("grid-extras-port"),
                 this.session.getExternalKey().getKey());
     }
 

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/VideoDownloaderCallable.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/VideoDownloaderCallable.java
@@ -23,14 +23,16 @@ public class VideoDownloaderCallable implements Callable {
     private static Logger logger = Logger.getLogger(VideoDownloaderCallable.class);
     private final String session;
     private final String host;
+    private final int nodePort;
     private final URI uri;
     private final int ATTEMPTS_TO_DOWNLOAD = 5;
     private final int TIME_TO_WAIT_BETWEEN_ATTEMPTS = 30000;
 
-    public VideoDownloaderCallable(String session, String host) {
+    public VideoDownloaderCallable(String session, String host, String nodePort) {
         logger.info(String.format("New instance for session: %s host: %s", session, host));
         this.session = session;
         this.host = host;
+        this.nodePort = Integer.parseInt(nodePort);
         this.uri = buildVideoStatusUri();
 
     }
@@ -187,7 +189,7 @@ public class VideoDownloaderCallable implements Callable {
         URIBuilder builder = new URIBuilder();
         builder.setScheme("http");
         builder.setHost(this.host);
-        builder.setPort(RuntimeConfig.getGridExtrasPort());
+        builder.setPort(this.nodePort);
         builder.setPath(TaskDescriptions.Endpoints.VIDEO);
 
         try {

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/VideoDownloaderCallable.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/utilities/threads/video/VideoDownloaderCallable.java
@@ -28,11 +28,11 @@ public class VideoDownloaderCallable implements Callable {
     private final int ATTEMPTS_TO_DOWNLOAD = 5;
     private final int TIME_TO_WAIT_BETWEEN_ATTEMPTS = 30000;
 
-    public VideoDownloaderCallable(String session, String host, String nodePort) {
+    public VideoDownloaderCallable(String session, String host, int nodePort) {
         logger.info(String.format("New instance for session: %s host: %s", session, host));
         this.session = session;
         this.host = host;
-        this.nodePort = Integer.parseInt(nodePort);
+        this.nodePort = nodePort;
         this.uri = buildVideoStatusUri();
 
     }

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/videorecording/RemoteVideoRecorderHelper.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/videorecording/RemoteVideoRecorderHelper.java
@@ -17,12 +17,12 @@ import java.util.Map;
 public class RemoteVideoRecorderHelper {
     private static Logger logger = Logger.getLogger(RemoteVideoRecorderHelper.class);
 
-    public static String startVideoRecording(String host, String port, String session) {
+    public static String startVideoRecording(String host, int port, String session) {
 
         URIBuilder builder = new URIBuilder();
         builder.setScheme("http");
         builder.setHost(host);
-        builder.setPort(Integer.valueOf(port));
+        builder.setPort(port);
         builder.setPath(TaskDescriptions.Endpoints.VIDEO);
 
         Map<String, String> params = getBlankParams(session, JsonCodec.Video.START);
@@ -51,12 +51,12 @@ public class RemoteVideoRecorderHelper {
 
     }
 
-    public static String stopVideoRecording(String host, String port, String session) {
+    public static String stopVideoRecording(String host, int port, String session) {
 
         URIBuilder builder = new URIBuilder();
         builder.setScheme("http");
         builder.setHost(host);
-        builder.setPort(Integer.valueOf(port));
+        builder.setPort(port);
         builder.setPath(TaskDescriptions.Endpoints.VIDEO);
 
         Map<String, String> params = getBlankParams(session, JsonCodec.Video.STOP);
@@ -84,11 +84,11 @@ public class RemoteVideoRecorderHelper {
 
     }
 
-    public static String updateLastAction(String host, String port, String session, String action) {
+    public static String updateLastAction(String host, int port, String session, String action) {
         URIBuilder builder = new URIBuilder();
         builder.setScheme("http");
         builder.setHost(host);
-        builder.setPort(Integer.valueOf(port));
+        builder.setPort(port);
         builder.setPath(TaskDescriptions.Endpoints.VIDEO);
 
         Map<String, String> params = getBlankParams(session, JsonCodec.Video.HEARTBEAT);

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/videorecording/RemoteVideoRecorderHelper.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/videorecording/RemoteVideoRecorderHelper.java
@@ -17,12 +17,12 @@ import java.util.Map;
 public class RemoteVideoRecorderHelper {
     private static Logger logger = Logger.getLogger(RemoteVideoRecorderHelper.class);
 
-    public static String startVideoRecording(String host, String session) {
+    public static String startVideoRecording(String host, String port, String session) {
 
         URIBuilder builder = new URIBuilder();
         builder.setScheme("http");
         builder.setHost(host);
-        builder.setPort(RuntimeConfig.getGridExtrasPort());
+        builder.setPort(Integer.valueOf(port));
         builder.setPath(TaskDescriptions.Endpoints.VIDEO);
 
         Map<String, String> params = getBlankParams(session, JsonCodec.Video.START);
@@ -33,7 +33,7 @@ public class RemoteVideoRecorderHelper {
         URI uri;
         String errorMessage = String.format("Error building URI for host: %s, port: %s, session: %s, action: %s, params: %s",
                 host,
-                RuntimeConfig.getGridExtrasPort(),
+                port,
                 session,
                 JsonCodec.Video.START,
                 params.toString());
@@ -51,12 +51,12 @@ public class RemoteVideoRecorderHelper {
 
     }
 
-    public static String stopVideoRecording(String host, String session) {
+    public static String stopVideoRecording(String host, String port, String session) {
 
         URIBuilder builder = new URIBuilder();
         builder.setScheme("http");
         builder.setHost(host);
-        builder.setPort(RuntimeConfig.getGridExtrasPort());
+        builder.setPort(Integer.valueOf(port));
         builder.setPath(TaskDescriptions.Endpoints.VIDEO);
 
         Map<String, String> params = getBlankParams(session, JsonCodec.Video.STOP);
@@ -66,7 +66,7 @@ public class RemoteVideoRecorderHelper {
         URI uri;
         String errorMessage = String.format("Error building URI for host: %s, port: %s, session: %s, action: %s, params: %s",
                 host,
-                RuntimeConfig.getGridExtrasPort(),
+                port,
                 session,
                 JsonCodec.Video.STOP,
                 params.toString());
@@ -84,11 +84,11 @@ public class RemoteVideoRecorderHelper {
 
     }
 
-    public static String updateLastAction(String host, String session, String action) {
+    public static String updateLastAction(String host, String port, String session, String action) {
         URIBuilder builder = new URIBuilder();
         builder.setScheme("http");
         builder.setHost(host);
-        builder.setPort(RuntimeConfig.getGridExtrasPort());
+        builder.setPort(Integer.valueOf(port));
         builder.setPath(TaskDescriptions.Endpoints.VIDEO);
 
         Map<String, String> params = getBlankParams(session, JsonCodec.Video.HEARTBEAT);
@@ -100,7 +100,7 @@ public class RemoteVideoRecorderHelper {
         URI uri;
         String errorMessage = String.format("Error building URI for host: %s, port: %s, session: %s, action: %s, params: %s",
                 host,
-                RuntimeConfig.getGridExtrasPort(),
+                port,
                 session,
                 JsonCodec.Video.HEARTBEAT,
                 params.toString());


### PR DESCRIPTION
Currently there is an issue reported in #284 and some other issues, where if the Grid Extras is listening in the port 3000, the node is expected to be listening on the same port.

This is a bigger issue if you're running selenium-grid-extras inside docker on different machines communicating between them.

I propose to use the selenium node custom configuration map to insert the property `grid-extras-port` so that the hub knows on which port is the grid-extras from the node listening on.