### PR TITLE
Add servlet to list add nodes addresses connected in the grid.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ launchctl load ~/Library/LaunchAgents/com.groupon.SeleniumGridExtras.plist
 ===================================================
 
 
+Docker Images
+-------------------
+https://github.com/viltgroup/docker-selenium-grid-extras provided by @mariolameiras . If you see any issues with these images please report them on the https://github.com/viltgroup/docker-selenium-grid-extras repo, and not this repo. These are new images, so please keep that in mind.
 
 
 Contributing

--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/servlets/ListNodesServlet.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/grid/servlets/ListNodesServlet.java
@@ -1,0 +1,67 @@
+package com.groupon.seleniumgridextras.grid.servlets;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.openqa.grid.internal.Registry;
+import org.openqa.grid.internal.ProxySet;
+import org.openqa.grid.internal.RemoteProxy;
+import org.openqa.grid.web.servlet.RegistryBasedServlet;
+import org.openqa.selenium.remote.JsonException;
+
+import com.google.gson.GsonBuilder;
+
+public class ListNodesServlet extends RegistryBasedServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public ListNodesServlet() {
+        this(null);
+    }
+
+    public ListNodesServlet(Registry registry) {
+        super(registry);
+    }
+
+     @Override
+     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+         doPost(req, resp);
+     }
+
+     @Override
+     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+         process(req, resp);
+     }
+
+     protected void process(HttpServletRequest request, HttpServletResponse response) throws IOException {
+         response.setContentType("application/json");
+         response.setCharacterEncoding("UTF-8");
+         response.setStatus(200);
+
+         response.getWriter().print(new GsonBuilder().setPrettyPrinting().create().toJson(getResponse()));
+         response.getWriter().close();
+     }
+
+     private Map<String, List<String>> getResponse() throws IOException, JsonException {
+         Map<String, List<String>> res = new HashMap<>();
+         ArrayList<String> nodeList = new ArrayList<>();
+
+         ProxySet proxies = this.getRegistry().getAllProxies();
+         Iterator<RemoteProxy> iterator = proxies.iterator();
+         while (iterator.hasNext()) {
+             RemoteProxy eachProxy = iterator.next();
+             nodeList.add(String.format("%s:%s", eachProxy.getConfig().host, eachProxy.getConfig().custom.get("grid_extras_port")));
+         }
+
+         res.put("nodeList", nodeList);
+         return res;
+     }
+}


### PR DESCRIPTION
Since we can customize the grid-extras-port in nodes https://github.com/groupon/Selenium-Grid-Extras/pull/385, the grid-extras-port of a node can be configured to be different from the value '3000'.

This is an issue, if you intent to communicate with a node through the the selenium grid extras API.

I propose a simple servlet to list all the node addresses (with the grid-extras-port configured) connected to the hub so that we can retrieve this information in an easy way:

![imagem](https://user-images.githubusercontent.com/6317573/37519770-4ab3af64-2912-11e8-85d4-91178981bebe.png)
