### PR TITLE
Download webdriver over HTTPS instead of HTTP

### DIFF
--- a/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/downloader/WdDownloader.java
+++ b/SeleniumGridExtras/src/main/java/com/groupon/seleniumgridextras/downloader/WdDownloader.java
@@ -50,7 +50,7 @@ public class WdDownloader extends Downloader {
       versionMajor = version.substring(0, version.lastIndexOf('.')) + version.substring(version.indexOf('-'));
     }
     
-    setSourceURL("http://selenium-release.storage.googleapis.com/" + versionMajor
+    setSourceURL("https://selenium-release.storage.googleapis.com/" + versionMajor
                  + "/selenium-server-standalone-" + destinationFile);
   }
 


### PR DESCRIPTION
Simple change to download the selenium-server-standalone jar via HTTPS instead of via HTTP.
I see that downloading of jar's or other executables via HTTP are being blocked more often by compagnies right now so I just made this simple change.
I face the same issue so downloading via HTTP is no longer permitted.
Would solve a lot of maintenance for me (and probably others) if you would accept this PR. Thanks!